### PR TITLE
README: add ruby 1.8.6 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ What Packages Are Available?
 3. Or run `brew server` to browse packages off of a local web server.
 4. Or visit [braumeister](http://braumeister.org) to browse packages online.
 
+Requirement
+-----------
+**Ruby** v1.8.6 or newer.
+
 More Documentation
 ------------------
 `brew help` or `man brew` or check the Homebrew [wiki](https://github.com/mxcl/homebrew/wiki).


### PR DESCRIPTION
For now, it seems that homebrew-core requires Ruby 1.8.6

Known limitations of Ruby 1.8.5:
- RUBY_PATCHLEVEL is not defined
- instance_variable_defined? is not defined
- pathname.rb:223 - 'Digest::SHA2' => 'Digest::SHA256' is necessary

closes #12

I will look into it a little bit more to see if it is worthwile supporting older versions of Ruby, but it was pointed out in #12 that supporting older versions (e.g. tigerbrew) leads to limitations in how homebrew functions. I think it's reasonable to have this requirement for now.
