### PR TITLE
Fix `brew home`

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -190,7 +190,7 @@ def exec_editor *args
 end
 
 def exec_browser *args
-  browser = ENV['HOMEBREW_BROWSER'] || ENV['BROWSER'] || "open"
+  browser = ENV['HOMEBREW_BROWSER'] || ENV['BROWSER'] || "xdg-open"
   safe_exec(browser, *args)
 end
 


### PR DESCRIPTION
On linux there is no `open` command, but there is `xdg-open` that provides the same functionality.
