### PR TITLE
cmake 2.8.12.2 (modified formula specifically for linuxbrew)

### DIFF
--- a/Library/Formula/cmake.rb
+++ b/Library/Formula/cmake.rb
@@ -1,24 +1,24 @@
 require 'formula'
 
-class NoExpatFramework < Requirement
-  def expat_framework
-    '/Library/Frameworks/expat.framework'
-  end
+# class NoExpatFramework < Requirement
+#   def expat_framework
+#     '/Library/Frameworks/expat.framework'
+#   end
 
-  satisfy :build_env => false do
-    not File.exist? expat_framework
-  end
+#   satisfy :build_env => false do
+#     not File.exist? expat_framework
+#   end
 
-  def message; <<-EOS.undent
-    Detected #{expat_framework}
+#   def message; <<-EOS.undent
+#     Detected #{expat_framework}
 
-    This will be picked up by CMake's build system and likely cause the
-    build to fail, trying to link to a 32-bit version of expat.
+#     This will be picked up by CMake's build system and likely cause the
+#     build to fail, trying to link to a 32-bit version of expat.
 
-    You may need to move this file out of the way to compile CMake.
-    EOS
-  end
-end
+#     You may need to move this file out of the way to compile CMake.
+#     EOS
+#   end
+# end
 
 class Cmake < Formula
   homepage 'http://www.cmake.org/'
@@ -27,21 +27,28 @@ class Cmake < Formula
 
   head 'http://cmake.org/cmake.git'
 
-  bottle do
-    cellar :any
-    revision 2
-    sha1 "e1e50cfd9f421b64365a7a2c34e9e6337f9391b7" => :mavericks
-    sha1 "9c60ed323f8752eb257d1505e33d70e4367e4219" => :mountain_lion
-    sha1 "1914f68373cdc8d1c99b4d76e1e1fed85e4303d3" => :lion
-  end
+  # bottle do
+  #   cellar :any
+  #   revision 2
+  #   sha1 "e1e50cfd9f421b64365a7a2c34e9e6337f9391b7" => :mavericks
+  #   sha1 "9c60ed323f8752eb257d1505e33d70e4367e4219" => :mountain_lion
+  #   sha1 "1914f68373cdc8d1c99b4d76e1e1fed85e4303d3" => :lion
+  # end
 
-  depends_on NoExpatFramework
+  # depends_on NoExpatFramework
 
   def install
+    # args = %W[
+    #   --prefix=#{prefix}
+    #   --system-libs
+    #   --no-system-libarchive
+    #   --datadir=/share/cmake
+    #   --docdir=/share/doc/cmake
+    #   --mandir=/share/man
+    # ]
+
     args = %W[
       --prefix=#{prefix}
-      --system-libs
-      --no-system-libarchive
       --datadir=/share/cmake
       --docdir=/share/doc/cmake
       --mandir=/share/man


### PR DESCRIPTION
removed --system-libs and --no-system-libarchive in args, but the second one is
a default, so it should matter, the first one does matter. Otherwise,
compilation complains about EXPAT framework.
