### PR TITLE
Add texinfo to base requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Features
 Installation
 ------------
 
-* Debian or Ubuntu: `sudo apt-get install build-essential curl git ruby libbz2-dev libcurl4-openssl-dev libexpat-dev libncurses-dev zlib1g-dev`
-* Fedora: `sudo yum groupinstall 'Development Tools' && sudo yum install curl git ruby bzip2-devel curl-devel expat-devel ncurses-devel zlib-devel`
+* Debian or Ubuntu: `sudo apt-get install build-essential curl git ruby libbz2-dev libcurl4-openssl-dev libexpat-dev libncurses-dev zlib1g-dev texinfo`
+* Fedora: `sudo yum groupinstall 'Development Tools' && sudo yum install curl git ruby bzip2-devel curl-devel expat-devel ncurses-devel zlib-devel texinfo`
 * `git clone https://github.com/Homebrew/linuxbrew.git ~/.linuxbrew`
 * Add to your `.bashrc` or `.zshrc`:
 


### PR DESCRIPTION
It will be required makeinfo by many formulae.
OSX (Xtools?) have it. So it's better to install texinfo by apt/yum.
