### PR TITLE
Support to print sha1 on bottling.

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -179,12 +179,18 @@ class BottleSpecification
   def checksums
     checksums = {}
     os_versions = collector.keys
-    os_versions.map! {|osx| MacOS::Version.from_symbol osx rescue nil }.compact!
+    os_versions.map! {|os|
+      if (OS.linux? and os == :linux)
+        "linux"
+      else
+        MacOS::Version.from_symbol os rescue nil
+      end
+    }.compact!
     os_versions.sort.reverse_each do |os_version|
-      osx = os_version.to_sym
-      checksum = collector[osx]
+      os = os_version.to_sym
+      checksum = collector[os]
       checksums[checksum.hash_type] ||= []
-      checksums[checksum.hash_type] << { checksum => osx }
+      checksums[checksum.hash_type] << { checksum => os }
     end
     checksums
   end


### PR DESCRIPTION
This PR is related on #74.
There doesn't output sha1 hash for generated bottles like this:

```
./hello-2.9.linux.bottle.tar.gz
  bottle do
    prefix "/home/azureuser/.linuxbrew"
    cellar "/home/azureuser/.linuxbrew/Cellar"
  end
```

After applied my patch, it'll show like this:

```
./hello-2.9.linux.bottle.tar.gz
  bottle do
    prefix "/home/azureuser/.linuxbrew"
    cellar "/home/azureuser/.linuxbrew/Cellar"
    sha1 "88aaf685c1bd21927ec94f28aae8ed46c6e4df50" => :linux
  end
```
