### PR TITLE
Restore ability to inherit compiler from environmental variables

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -62,7 +62,7 @@ module Stdenv
 
     append 'LDFLAGS', '-Wl,-headerpad_max_install_names'
 
-    send(compiler)
+    send(compiler) unless inherit?
     validate_cc!(formula) unless formula.nil?
 
     if !inherit? && cc =~ GNU_GCC_REGEXP


### PR DESCRIPTION
A recent update merge removed one of the flags that allows inheriting environmental variables:

https://github.com/Homebrew/linuxbrew/pull/29

This is needed for compiling on linux clusters where up to date gcc's are not in /usr/bin (chapmanb/bcbio-nextgen#424). This fix restores the previous behavior.

Thanks much
