### PR TITLE
FAAC doesn't compile on GNU/Linux

### DIFF
--- a/Library/Formula/faac.rb
+++ b/Library/Formula/faac.rb
@@ -12,9 +12,31 @@ class Faac < Formula
     sha1 "88bd2a82586156372015b7a884809a2d14d127cb" => :lion
   end
 
+  patch :DATA
+
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make install"
   end
 end
+
+__END__
+diff -Naur faac-1.28-orig/common/mp4v2/mpeg4ip.h faac-1.28/common/mp4v2/mpeg4ip.h
+--- faac-1.28-orig/common/mp4v2/mpeg4ip.h	2009-01-26 22:42:35.000000000 +0000
++++ faac-1.28/common/mp4v2/mpeg4ip.h	2009-08-04 13:45:47.728062591 +0100
+@@ -120,14 +120,6 @@
+ #endif
+ #include <sys/param.h>
+
+-#ifdef __cplusplus
+-extern "C" {
+-#endif
+-char *strcasestr(const char *haystack, const char *needle);
+-#ifdef __cplusplus
+-}
+-#endif
+-
+ #define OPEN_RDWR O_RDWR
+ #define OPEN_CREAT O_CREAT
+ #define OPEN_RDONLY O_RDONLY


### PR DESCRIPTION
Due to a known conflict between FAAC and GNU libc (http://sourceforge.net/p/faac/bugs/162/, http://stackoverflow.com/questions/4320226/installing-faac-on-linux-getting-errors), faac 1.28 doesn't compile on glibc-2.10 and later versions.

As many GNU/Linux distros do, the redundant declaration `strcasestr` in `common/mp4v2/mpeg4ip.h` needs to be removed to resolve its conflict with glibc. (Here's a [patch](http://www.linuxfromscratch.org/patches/blfs/svn/faac-1.28-glibc_fixes-1.patch) from LFS)
