### PR TITLE
ffmpeg: Should LDFLAGS "-Wl,-headerpad_max_install_names" be removed from linuxbrew?

### DIFF
--- a/Library/Formula/ffmpeg.rb
+++ b/Library/Formula/ffmpeg.rb
@@ -112,6 +112,8 @@ class Ffmpeg < Formula
 
     ENV["GIT_DIR"] = cached_download/".git" if build.head?
 
+    ENV.remove SharedEnvExtension::SANITIZED_VARS, '-Wl,-headerpad_max_install_names'
+
     system "./configure", *args
 
     if MacOS.prefer_64_bit?


### PR DESCRIPTION
Since `-Wl,-headerpad_max_install_names` has been made as a default compiler flag according to this Homebrew issue https://github.com/Homebrew/homebrew/issues/20233 , this does not simply scale to GNU/Linux well.

As far as I can tell, this LDFLAGS option (`-headerpad_max_install_names`) can cause GNU linker to fail during linking, at least for **ffmpeg**:

```
...
libavdevice/libavdevice.so: undefined reference to `av_file_map'
libavdevice/libavdevice.so: undefined reference to `av_image_copy'
libavdevice/libavdevice.so: undefined reference to `avfilter_get_by_name@LIBAVFILTER_4'
libavdevice/libavdevice.so: undefined reference to `av_opt_set_bin'
libavdevice/libavdevice.so: undefined reference to `av_frame_get_pkt_pos'
libavdevice/libavdevice.so: undefined reference to `avpicture_layout'
collect2: error: ld returned 1 exit status
make: *** [ffmpeg_g] Error 1
make: *** Waiting for unfinished jobs....
Error: Homebrew doesn't know what compiler versions ship with your version
of Xcode (0). Please `brew update` and if that doesn't help, file
an issue with the output of `brew --config`:
  https://github.com/Homebrew/homebrew/issues

Note that we only track stable, released versions of Xcode.

Thanks!
```

`-headerpad_max_install_names` is a Darwin-only option (https://gcc.gnu.org/onlinedocs/gcc/Darwin-Options.html). It's supposed to be only passed to a Darwin linker. For GNU/Linux users, it has no use case at all.

My question is,
1. Should we do a temporary hack, just for one package, like this PR suggests?
2. Or, should we remove this LDFLAGS from linuxbrew globally?

Thanks!
