### PR TITLE
warn depend_on :macos on linux platform

### DIFF
--- a/Library/Homebrew/requirements/minimum_macos_requirement.rb
+++ b/Library/Homebrew/requirements/minimum_macos_requirement.rb
@@ -1,7 +1,7 @@
 require 'requirement'
 
 class MinimumMacOSRequirement < Requirement
-  fatal true
+  fatal OS.mac?
 
   def initialize(tags)
     @version = MacOS::Version.from_symbol(tags.first)


### PR DESCRIPTION
before

```
$ brew install passenger
passenger: OS X Mountain Lion or newer is required.
Error: An unsatisfied requirement failed this build.
```

after

```
$ brew install passenger
passenger: OS X Mountain Lion or newer is required.
==> Downloading http://s3.amazonaws.com/phusion-passenger/releases/passenger-4.0.45.tar.gz
Already downloaded: /var/cache/Homebrew/passenger-4.0.45.tar.gz
==> /usr/local/var/rbenv/versions/2.1.1/bin/rake apache2
```
