### PR TITLE
tbb: Fix TBB installation on Linux machines.

### DIFF
--- a/Library/Formula/tbb.rb
+++ b/Library/Formula/tbb.rb
@@ -13,6 +13,7 @@ class Tbb < Formula
     ENV.no_optimization
 
     args = %W[tbb_build_prefix=BUILDPREFIX]
+
     case ENV.compiler
     when :clang
       args << "compiler=clang"
@@ -26,9 +27,6 @@ class Tbb < Formula
       else
         args << "arch=ia32"
       end
-    else
-      args << "compiler=gcc"
-      args << "arch=intel64"
     end
 
     if build.cxx11?


### PR DESCRIPTION
In the homebrew formula there are a bunch of mac-specific bits that cause installation to fail on Linux, this swaps the installation to be Linux specific and fixes the installation issues. It is tested and works properly.
