### PR TITLE
Formula/ActiveMQ - Don't remove linux folder

### DIFF
--- a/Library/Formula/activemq.rb
+++ b/Library/Formula/activemq.rb
@@ -8,8 +8,6 @@ class Activemq < Formula
   skip_clean 'libexec/webapps/admin/WEB-INF/jsp'
 
   def install
-    rm_rf Dir['bin/linux-x86-*']
-
     prefix.install_metafiles
     libexec.install Dir['*']
 


### PR DESCRIPTION
For linux installation, we need this to run a Message Broker Server.
