### PR TITLE
Fix for ruby.rb (prevents a configure error under Linux).

### DIFF
--- a/Library/Formula/ruby.rb
+++ b/Library/Formula/ruby.rb
@@ -48,7 +48,7 @@ class Ruby < Formula
     args << "--with-arch=#{Hardware::CPU.universal_archs.join(',')}" if build.universal?
     args << "--with-out-ext=tk" if build.without? "tcltk"
     args << "--disable-install-doc" if build.without? "doc"
-    args << "--disable-dtrace" unless MacOS::CLT.installed?
+    args << "--disable-dtrace" unless (OS.mac? and MacOS::CLT.installed?)
     args << "--without-gmp" if build.without? "gmp"
 
     paths = [


### PR DESCRIPTION
The `MacOS::CLT.installed?` check manifests as a very nondescript configure error.

There may be a more pervasive way of fixing these issues for all formulae, I'm not sure. This works locally for me to allow ruby in be installed.
