### PR TITLE
Set rpath correctly

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -59,7 +59,7 @@ module Stdenv
 
     # Set the dynamic library search path
     if OS.linux?
-      append "LDFLAGS", "-Wl,-rpath #{HOMEBREW_PREFIX}/lib"
+      append "LDFLAGS", "-Wl,-rpath,#{HOMEBREW_PREFIX}/lib"
       self["LD_RUN_PATH"] = "#{HOMEBREW_PREFIX}/lib"
     end
 


### PR DESCRIPTION
Without this the `#{HOMEBREW_PREFIX}/lib` part gets dropped from linker invocations.
