### PR TITLE
Ignore .so files with soname versioning builtin when linking kegs

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -62,6 +62,7 @@ module FormulaCellarChecks
                           .jar .prl .pm .sh)
     non_libraries = f.lib.children.select do |g|
       next if g.directory?
+      next if /.*\.so[.\d]*/.match(g.basename)
       not valid_extensions.include? g.extname
     end
     return if non_libraries.empty?


### PR DESCRIPTION
I don't know of any formulae that install cleanly on Linux and install naughty files to `lib` so I can't double-check that this still fails when it's supposed to, but this silences the pesky warnings about `libfoo.so.4.5` being a non-lib file.
