### PR TITLE
Fixed mirror url for pkg-config.rb

### DIFF
--- a/Library/Formula/pkg-config.rb
+++ b/Library/Formula/pkg-config.rb
@@ -3,7 +3,7 @@ require 'formula'
 class PkgConfig < Formula
   homepage 'http://pkgconfig.freedesktop.org'
   url 'http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz'
-  mirror 'http://fossies.org/unix/privat/pkg-config-0.28.tar.gz'
+  mirror 'http://fossies.org/linux/misc/pkg-config-0.28.tar.gz'
   sha256 '6b6eb31c6ec4421174578652c7e141fdaae2dabad1021f420d8713206ac1f845'
 
   bottle do


### PR DESCRIPTION
I was trying to brew install extempore and it broke on the pkg-config.rb step after the primary url timed out.
Updated the url to fix.

Thanks,

Felix
