### PR TITLE
Added --without-crypto to libxslt configure options.

### DIFF
--- a/Library/Formula/libxslt.rb
+++ b/Library/Formula/libxslt.rb
@@ -17,7 +17,7 @@ class Libxslt < Formula
   depends_on 'libxml2'
 
   def install
-    system "./configure", "--disable-dependency-tracking",
+    system "./configure", "--disable-dependency-tracking", "--without-crypto",
                           "--prefix=#{prefix}",
                           "--with-libxml-prefix=#{Formula["libxml2"].prefix}"
     system "make"


### PR DESCRIPTION
To avoid the dependency on libgcrypt that leads to the following error:

```
checking for libgcrypt-config... /usr/bin/libgcrypt-config
Crypto extensions will be available.
...
crypto.c:330:20: fatal error: gcrypt.h: No such file or directory
```
