### PR TITLE
Avoid patching LINKFORSHARED in python Makefile on Linux

### DIFF
--- a/Library/Formula/python.rb
+++ b/Library/Formula/python.rb
@@ -148,7 +148,7 @@ class Python < Formula
     inreplace lib_cellar/"config/Makefile" do |s|
       s.change_make_var! "LINKFORSHARED",
         "-u _PyMac_Error $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)"
-    end
+    end if OS.mac?
 
     # Remove the site-packages that Python created in its Cellar.
     site_packages_cellar.rmtree


### PR DESCRIPTION
Patching the LINKFORSHARED will break the linker when building software depends on python.
For example, vim +python support will be disabled because of this.
