### PR TITLE
Assume Linux systems have X11 installed

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -231,6 +231,7 @@ module Stdenv
   end
 
   def x11
+    return unless OS.mac?
     # There are some config scripts here that should go in the PATH
     append_path "PATH", MacOS::X11.bin.to_s
 

--- a/Library/Homebrew/requirements/x11_dependency.rb
+++ b/Library/Homebrew/requirements/x11_dependency.rb
@@ -19,7 +19,11 @@ class X11Dependency < Requirement
   end
 
   satisfy :build_env => false do
-    MacOS::XQuartz.installed? && min_version <= Version.new(MacOS::XQuartz.version)
+    if OS.mac?
+      MacOS::XQuartz.installed? && min_version <= Version.new(MacOS::XQuartz.version)
+    else
+      true
+    end
   end
 
   def message; <<-EOS.undent


### PR DESCRIPTION
As discussed in issue #164 , this patch is a simplified version of pull request #64 which skirts X11 dependencies on linux.

The original patch seems to be trying to validate X11 installation by checking the `xterm --version`, but
it doesn't seem to be finished. This patch just assumes you have X11 installed if you are on linux.

This seems like an acceptable holdover until something along the lines of #64 is figured out.
