### PR TITLE
Change autoconf perl env to which perl

### DIFF
--- a/Library/Formula/autoconf.rb
+++ b/Library/Formula/autoconf.rb
@@ -17,7 +17,7 @@ class Autoconf < Formula
   keg_only :provided_until_xcode43
 
   def install
-    ENV['PERL'] = '/usr/bin/perl'
+    ENV['PERL'] = '/usr/bin/perl' if OS.mac?
 
     # force autoreconf to look for and use our glibtoolize
     inreplace 'bin/autoreconf.in', 'libtoolize', 'glibtoolize'

--- a/Library/Formula/automake.rb
+++ b/Library/Formula/automake.rb
@@ -18,7 +18,7 @@ class Automake < Formula
   keg_only :provided_until_xcode43
 
   def install
-    ENV['PERL'] = '/usr/bin/perl'
+    ENV['PERL'] = '/usr/bin/perl' if OS.mac?
 
     system "./configure", "--prefix=#{prefix}"
     system "make install"


### PR DESCRIPTION
This fixes an issue where autoconf cannot find perl if it isn't in `/usr/local/bin`.
