### PR TITLE
python: compile shared object files

### DIFF
--- a/Library/Formula/python.rb
+++ b/Library/Formula/python.rb
@@ -82,7 +82,6 @@ class Python < Formula
     # and not into some other Python the user has installed.
     ENV["PYTHONHOME"] = nil
     ENV["PYTHONPATH"] = nil
-    ENV["CFLAGS"] += " -fPIC" if OS.linux?
 
     args = %W[
              --prefix=#{prefix}


### PR DESCRIPTION
This makes python create `libpython.2.7.so`. This file is important for, among other things, compiling YouCompleteMe with CMake.
