### PR TITLE
jdk 1.8.0-25: New formula for Linuxbrew

### DIFF
--- a/Library/Formula/jdk.rb
+++ b/Library/Formula/jdk.rb
@@ -1,0 +1,24 @@
+require "formula"
+
+class Jdk < Formula
+  homepage "http://www.java.com/"
+
+  version "1.8.0-25"
+  if OS.linux?
+    url "http://download.oracle.com/otn-pub/java/jdk/8u25-b17/jdk-8u25-linux-x64.tar.gz"
+    sha1 "0eb0448641c21c435cddc4705d23668d45f29fff"
+  elsif OS.mac?
+    raise "On Mac OS try instead `brew cask install java`"
+  else
+    raise "Unknown operating system"
+  end
+
+  def install
+    prefix.install Dir["*"]
+  end
+
+  test do
+    system "#{bin}/java", "-version"
+    system "#{bin}/javac", "-version"
+  end
+end


### PR DESCRIPTION
This formula doesn't work out-of-the-box because Oracle requires accepting click-through license, which doesn't work with curl. You can instead download the file and save it as
`~/.cache/Homebrew/jdk-1.8.0-25.tar.gz`, then run
`brew install https://raw.githubusercontent.com/Homebrew/linuxbrew/jdk/Library/Formula/jdk.rb`.
