### PR TITLE
openssl: set proper architecture for 32-bit system

### DIFF
--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -26,7 +26,7 @@ class Openssl < Formula
     "Apple has deprecated use of OpenSSL in favor of its own TLS and crypto libraries"
 
   def arch_args
-    return { :i386  => %w[linux-x86_64], :x86_64 => %w[linux-x86_64] } if OS.linux?
+    return { :i386  => %w[linux-generic32], :x86_64 => %w[linux-x86_64] } if OS.linux?
     {
       :x86_64 => %w[darwin64-x86_64-cc enable-ec_nistp_64_gcc_128],
       :i386   => %w[darwin-i386-cc],


### PR DESCRIPTION
Set the proper architecture when compiling OpenSSL on a 32-bit system.

Closes #224.
