### PR TITLE
.travis.yml: disable emails & enable fast_finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,7 @@ install:
  - PATH=$PWD/bin:$PATH
 script:
  - brew test-bot --dry-run $TRAVIS_COMMIT |sed -n 's/^==> //p' |sh -ex
+notifications:
+    email: false
+matrix:
+    fast_finish: true


### PR DESCRIPTION
Closes #248. I am not aware of any other way to fix it.

Fast_finish makes the whole build as failed if one build fails instead
of having to wait for all builds to finish. It's probably not needed
yet, but it don't hurt to have there and it's probably possible that
there can be more builds in the future.