### PR TITLE
xrootd: no need to fix manpath on linux (GNUInstallDirs is used)

### DIFF
--- a/Library/Formula/xrootd.rb
+++ b/Library/Formula/xrootd.rb
@@ -20,7 +20,7 @@ class Xrootd < Formula
       system "cmake", "..", *std_cmake_args
       system "make", "install"
     end
-    share.install prefix/"man"
+    share.install prefix/"man" unless OS.linux?
   end
 
   test do


### PR DESCRIPTION
The install paths handling is different on linux and it's already homebrew complaint so we don't have to fix it:
https://github.com/xrootd/xrootd/blob/4d465799a237523651883faf8f4b09b09d5918d5/cmake/XRootDOSDefs.cmake#L32-L55