### PR TITLE
go: fix sha1

### DIFF
--- a/Library/Formula/go.rb
+++ b/Library/Formula/go.rb
@@ -4,7 +4,7 @@ class Go < Formula
   # Perhaps we can use our previous bottles, ala the discussion around PyPy?
   # https://docs.google.com/document/d/1OaatvGhEAq7VseQ9kkavxKNAfepWy2yhPUBs96FGV28
   url "https://storage.googleapis.com/golang/go1.4.1.src.tar.gz"
-  sha1 "d77dbbb06d7a005966ced0b837bc6c97d541210f"
+  sha1 "c7a683e8d39b835e333199d68d0c0baefcd24a68"
   version "1.4.1"
 
   head "https://go.googlesource.com/go", :using => :git


### PR DESCRIPTION
https://golang.org/dl/ has a SHA1 matching the Actual reported by brew.

Currently brew is reporting a mismatch:
/linuxbrew$ brew install go
==> Downloading https://storage.googleapis.com/golang/go1.4.1.src.tar.gz
Already downloaded: /opt/boxen/cache/homebrew/go-1.4.1.tar.gz
Error: SHA1 mismatch
Expected: d77dbbb06d7a005966ced0b837bc6c97d541210f
Actual: c7a683e8d39b835e333199d68d0c0baefcd24a68
Archive: /opt/boxen/cache/homebrew/go-1.4.1.tar.gz
To retry an incomplete download, remove the file above.
