### PR TITLE
Add yum install irb to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ sudo apt-get install build-essential curl git m4 ruby texinfo libbz2-dev libcurl
 ### Fedora
 
 ```sh
-sudo yum groupinstall 'Development Tools' && sudo yum install curl git m4 ruby texinfo bzip2-devel curl-devel expat-devel ncurses-devel zlib-devel
+sudo yum groupinstall 'Development Tools' && sudo yum install curl git m4 ruby irb texinfo bzip2-devel curl-devel expat-devel ncurses-devel zlib-devel
 ```
 
 Installation


### PR DESCRIPTION
To avoid an Error on my centos box.

In my centos, ``brew install tmux`` hit an error missing irb.

```
bash-4.1$ brew install tmux
Error: no such file to load -- irb
Please report this bug:
    https://github.com/Homebrew/linuxbrew/blob/master/share/doc/homebrew/Troubleshooting.md#troubleshooting
/home/matope/.linuxbrew/Library/Homebrew/debrew/irb.rb:1:in `require'
/home/matope/.linuxbrew/Library/Homebrew/debrew/irb.rb:1
/home/matope/.linuxbrew/Library/Homebrew/debrew.rb:2:in `require'
/home/matope/.linuxbrew/Library/Homebrew/debrew.rb:2
/home/matope/.linuxbrew/Library/Homebrew/formula_installer.rb:13:in `require'
/home/matope/.linuxbrew/Library/Homebrew/formula_installer.rb:13
/home/matope/.linuxbrew/Library/Homebrew/cmd/install.rb:5:in `require'
/home/matope/.linuxbrew/Library/Homebrew/cmd/install.rb:5
/home/matope/.linuxbrew/Library/brew.rb:58:in `require'
/home/matope/.linuxbrew/Library/brew.rb:58:in `require?'
/home/matope/.linuxbrew/Library/brew.rb:117
```

I added irb yum package. And then it's fixed.

Could you please review this README fix and merge if it's ok?