### PR TITLE
vim 7.4.488: Fix for Linuxbrew

### DIFF
--- a/Library/Formula/vim.rb
+++ b/Library/Formula/vim.rb
@@ -32,6 +32,7 @@ class Vim < Formula
   depends_on "lua" => :optional
   depends_on "luajit" => :optional
   depends_on "gtk+" if build.with? "client-server"
+  depends_on "homebrew/dupes/ncurses" => :build
 
   conflicts_with "ex-vi",
     :because => "vim and ex-vi both install bin/ex and bin/view"


### PR DESCRIPTION
Hi.
In my centos 6.5, ``brew install vim`` fails due to missing of link to `ncurses`.
When I added ``homebrew/dupes/ncurses`` to depends_on, install succeeded.
So I'd like to send patch, but I'm not sure if this is a correct way to solve it (Can I specify dupes formula as a depends_on ?).
Could you please review this patch?