### PR TITLE
aria2: remove dependency on appletls

### DIFF
--- a/Library/Formula/aria2.rb
+++ b/Library/Formula/aria2.rb
@@ -24,6 +24,7 @@ class Aria2 < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "openssl"
 
   needs :cxx11
 
@@ -31,8 +32,8 @@ class Aria2 < Formula
     args = %W[
       --disable-dependency-tracking
       --prefix=#{prefix}
-      --with-appletls
-      --without-openssl
+      --without-appletls
+      --with-openssl
       --without-gnutls
       --without-libgmp
       --without-libnettle


### PR DESCRIPTION
Linux doesn't have appletls, using OpenSSL instead