### PR TITLE
icecast: depends on libxslt and curl

### DIFF
--- a/Library/Formula/icecast.rb
+++ b/Library/Formula/icecast.rb
@@ -17,6 +17,8 @@ class Icecast < Formula
   depends_on 'speex'  => :optional
   depends_on 'openssl'
   depends_on 'libvorbis'
+  depends_on 'libxslt' unless OS.mac?
+  depends_on 'curl' unless OS.mac?
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
See Homebrew/homebrew#36636.

In trying to install this, I got numerous errors. Fixed by adding a depends_on libxslt and depends_on curl.

These are installed by default on macs, but they must be installed on a non-Mac platform i.e. an Ubuntu with linuxbrew.