### PR TITLE
a2ps 4.14: Requires gperf on Linuxbrew

### DIFF
--- a/Library/Formula/a2ps.rb
+++ b/Library/Formula/a2ps.rb
@@ -4,6 +4,8 @@ class A2ps < Formula
   mirror "http://ftp.gnu.org/gnu/a2ps/a2ps-4.14.tar.gz"
   sha1 "365abbbe4b7128bf70dad16d06e23c5701874852"
 
+  depends_on "homebrew/dupes/gperf" unless OS.mac?
+
   bottle do
     sha1 "c33f22a088a0b1ed22efff0165722e87495a4bd0" => :yosemite
     sha1 "7ae09c9835ebb1913b97cf5f06bab42a0d1f33a6" => :mavericks


### PR DESCRIPTION
Per #219 and new policy in #280, require homebrew/dupes/gperf for Linuxbrew.  (I'm just going through formula to see if they install properly without using apt-get dependencies using throwaway cloud VM's).  There may be a better way to go about it, maybe a homebrw-linuxbrew-dupes?

I'm getting a possibly unrelated error while installing.  That may be because gperf itself isn't perfected for linux.  https://gist.github.com/anonymous/f0be8f2ba8ea64fbbff8.  It might go away in tests.