### PR TITLE
cmd-search: Remove Caskroom from searchable taps

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -77,7 +77,6 @@ module Homebrew
     %w{Homebrew python},
     %w{Homebrew php},
     %w{Homebrew x11},
-    %w{Caskroom cask},
   ]
 
   def query_regexp(query)


### PR DESCRIPTION
Fixes #284 