### PR TITLE
a52dec 0.7.4: Requires CPPFLAGS=-fPIC

### DIFF
--- a/Library/Formula/a52dec.rb
+++ b/Library/Formula/a52dec.rb
@@ -11,6 +11,7 @@ class A52dec < Formula
                           "--prefix=#{prefix}",
                           "--enable-shared",
                           "--mandir=#{man}"
-    system "make install"
+    system "make install CPPFLAGS=-fPIC" unless OS.mac?
+    system "make install" unless not OS.mac?
   end
 end


### PR DESCRIPTION
a52dec 0.7.4 requires CPPFLACS=-fPIC to compile on linux (log of failure in current state: https://gist.github.com/anonymous/7dddfe49dafd8070448d).

I don't know exactly how this should be merged.  Since it is a system command, I can't exactly append the CPPFLAGS=-fPIC on a new line.  My ruby is crap so I did the best I could (an unless OS.mac and unless not OS.mac for the old behavior) - it doesn't look good and will likely be a headache for merge conflicts in Homebrew but it's a start.