### PR TITLE
boost: Add option to build boost with brewed bzip2.

### DIFF
--- a/Library/Formula/boost.rb
+++ b/Library/Formula/boost.rb
@@ -96,6 +96,12 @@ class Boost < Formula
             "--user-config=user-config.jam",
             "install"]
 
+    if OS.linux?
+      args += ["include=#{HOMEBREW_PREFIX}/include",
+               "cflags=-L#{HOMEBREW_PREFIX}/lib",
+               "cxxflags=-L#{HOMEBREW_PREFIX}/lib"]
+    end
+
     if build.with? "single"
       args << "threading=multi,single"
     else


### PR DESCRIPTION
Not sure if this is best place for it, but I was guessing linuxbrew because bzip2 headers and libs should typically be installed on OS X, but might not be on linux.