### PR TITLE
Determine sqlite include path for python on linux as well.

### DIFF
--- a/Library/Formula/python.rb
+++ b/Library/Formula/python.rb
@@ -103,8 +103,11 @@ class Python < Formula
     # http://docs.python.org/library/sqlite3.html#f1
     if build.with? "sqlite"
       inreplace("setup.py", 'sqlite_defines.append(("SQLITE_OMIT_LOAD_EXTENSION", "1"))', "")
+      if Formula['sqlite'].installed?
+        inreplace("setup.py", /if host_platform == 'darwin':\s*# This should work on any unixy platform ;-\)/,
+                  "if host_platform == 'darwin' or 'linux' in host_platform:")
+      end
     end
-
     # Allow python modules to use ctypes.find_library to find homebrew's stuff
     # even if homebrew is not a /usr/local/lib. Try this with:
     # `brew install enchant && pip install pyenchant`

--- a/Library/Formula/python3.rb
+++ b/Library/Formula/python3.rb
@@ -106,7 +106,13 @@ class Python3 < Formula
     end
 
     # Allow sqlite3 module to load extensions: http://docs.python.org/library/sqlite3.html#f1
-    inreplace("setup.py", 'sqlite_defines.append(("SQLITE_OMIT_LOAD_EXTENSION", "1"))', "pass") if build.with? "sqlite"
+    if build.with? "sqlite"
+      inreplace("setup.py", 'sqlite_defines.append(("SQLITE_OMIT_LOAD_EXTENSION", "1"))', "pass")
+      if Formula['sqlite'].installed?
+        inreplace("setup.py", /if host_platform == 'darwin':\s*# This should work on any unixy platform ;-\)/,
+                  "if host_platform == 'darwin' or 'linux' in host_platform:")
+      end
+    end
 
     # Allow python modules to use ctypes.find_library to find homebrew's stuff
     # even if homebrew is not a /usr/local/lib. Try this with:


### PR DESCRIPTION
Python's setup.py extracts include/lib paths from -I, -L sysconfig vars when the os is darwin, but it even says in the comments it should work for unixy os as well! The point is that setup.py tries to build the sqlite3 extension looking for system sqlite3, which either may not exist, or is not what you want when linking to brew built sqlite3. This is why I think it shouldn't be a flag option like --with-brewed-sqlite.