### PR TITLE
curl: disable LDAP on linux

### DIFF
--- a/Library/Formula/curl.rb
+++ b/Library/Formula/curl.rb
@@ -22,6 +22,7 @@ class Curl < Formula
   option "with-libmetalink", "Build with libmetalink support."
   option "with-libressl", "Build with LibreSSL instead of Secure Transport or OpenSSL"
   option "with-nghttp2", "Build with HTTP/2 support (requires OpenSSL or LibreSSL)"
+  option "without-ldap", "Build without LDAP support"
 
   deprecated_option "with-idn" => "with-libidn"
   deprecated_option "with-rtmp" => "with-rtmpdump"
@@ -89,6 +90,7 @@ class Curl < Formula
     else
       args << "--disable-ares"
     end
+    args << "--disable-ldap" if build.without? "ldap"
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
This was the fix to #127, added in 65d490d54b8c4df811d0f23f197a262e8edfb5b6 but it must have been removed at some point.  For me, at least, it's still necessary; I get the same error (xubuntu 14.04.2).
```
HOMEBREW_VERSION: 0.9.5
ORIGIN: https://github.com/Homebrew/linuxbrew.git
HEAD: aee223b4ff6ce184873283d19c9de3e83c54bf9c
Last commit: 13 minutes ago
HOMEBREW_PREFIX: /home/alix/.linuxbrew
HOMEBREW_CELLAR: /home/alix/.linuxbrew/Cellar
CPU: dual-core 64-bit 6
OS X: 0-x86_64
Xcode: N/A
CLT: N/A
Clang: N/A
X11: N/A
System Ruby: 1.9.3-p484 => /usr/bin/ruby1.9.1
Perl: /usr/bin/perl
Python: /home/alix/.linuxbrew/bin/python => /home/alix/.linuxbrew/Cellar/python/2.7.9/bin/python2.7
Ruby: /usr/bin/ruby => /usr/bin/ruby1.9.1
Java: N/A
```