### PR TITLE
Fix rtmpdump and libbluray for Linux

### DIFF
--- a/Library/Formula/libbluray.rb
+++ b/Library/Formula/libbluray.rb
@@ -19,13 +19,17 @@ class Libbluray < Formula
     depends_on "ant" => :build
   end
 
+  if OS.linux?
+    depends_on "libxml2" => :build
+  end
   depends_on "pkg-config" => :build
   depends_on "freetype" => :recommended
   depends_on "fontconfig"
 
   def install
-    # https://mailman.videolan.org/pipermail/libbluray-devel/2014-April/001401.html
-    ENV.append_to_cflags "-D_DARWIN_C_SOURCE"
+    if OS.mac?  # https://mailman.videolan.org/pipermail/libbluray-devel/2014-April/001401.html
+      ENV.append_to_cflags "-D_DARWIN_C_SOURCE"
+    end
     ENV.libxml2
 
     args = %W[--prefix=#{prefix} --disable-dependency-tracking]

--- a/Library/Formula/libbluray.rb
+++ b/Library/Formula/libbluray.rb
@@ -19,17 +19,14 @@ class Libbluray < Formula
     depends_on "ant" => :build
   end
 
-  if OS.linux?
-    depends_on "libxml2" => :build
-  end
   depends_on "pkg-config" => :build
   depends_on "freetype" => :recommended
   depends_on "fontconfig"
+  depends_on "libxml2" if OS.linux?
 
   def install
-    if OS.mac?  # https://mailman.videolan.org/pipermail/libbluray-devel/2014-April/001401.html
-      ENV.append_to_cflags "-D_DARWIN_C_SOURCE"
-    end
+    # https://mailman.videolan.org/pipermail/libbluray-devel/2014-April/001401.html
+    ENV.append_to_cflags "-D_DARWIN_C_SOURCE" if OS.mac?
     ENV.libxml2
 
     args = %W[--prefix=#{prefix} --disable-dependency-tracking]

--- a/Library/Formula/rtmpdump.rb
+++ b/Library/Formula/rtmpdump.rb
@@ -27,20 +27,12 @@ class Rtmpdump < Formula
   end
 
   def install
-    if OS.mac?
-      sys = 'darwin'
-    elsif OS.linux?
-      sys = 'posix'
-    else
-      raise 'Unknown operating system'
-    end
-
     ENV.deparallelize
     system "make", "CC=#{ENV.cc}",
                    "XCFLAGS=#{ENV.cflags}",
                    "XLDFLAGS=#{ENV.ldflags}",
                    "MANDIR=#{man}",
-                   "SYS=#{sys}",
+                   "SYS=#{OS.mac? ? "darwin" : "posix"}",
                    "prefix=#{prefix}",
                    "sbindir=#{bin}",
                    "install"

--- a/Library/Formula/rtmpdump.rb
+++ b/Library/Formula/rtmpdump.rb
@@ -27,12 +27,20 @@ class Rtmpdump < Formula
   end
 
   def install
+    if OS.mac?
+      sys = 'darwin'
+    elsif OS.linux?
+      sys = 'posix'
+    else
+      raise 'Unknown operating system'
+    end
+
     ENV.deparallelize
     system "make", "CC=#{ENV.cc}",
                    "XCFLAGS=#{ENV.cflags}",
                    "XLDFLAGS=#{ENV.ldflags}",
                    "MANDIR=#{man}",
-                   "SYS=darwin",
+                   "SYS=#{sys}",
                    "prefix=#{prefix}",
                    "sbindir=#{bin}",
                    "install"


### PR DESCRIPTION
rtmpdump doesn't build on Linux. I have added a fix.
I also have added libxml2 dependency to libbluray (only on Linux, to simplify setup).