### PR TITLE
Allows the openssl formula to build when pkg-config is not present

### DIFF
--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -23,6 +23,7 @@ class Openssl < Formula
   option "without-check", "Skip build-time tests (not recommended)"
 
   depends_on "makedepend" => :build
+  depends_on "pkg-config" => :build
 
   keg_only :provided_by_osx,
     "Apple has deprecated use of OpenSSL in favor of its own TLS and crypto libraries"


### PR DESCRIPTION
- pkg-config is not always installed
- makedepend has a build dependency on pkg-config, since openssl has build dependency on makedepend, it should also have a build dependency on pkg-config