### PR TITLE
fpp 0.5.4 (new recipe)

### DIFF
--- a/Library/Formula/fpp.rb
+++ b/Library/Formula/fpp.rb
@@ -1,0 +1,19 @@
+class Fpp < Formula
+  homepage "https://facebook.github.io/PathPicker/"
+  url "https://facebook.github.io/PathPicker/dist/fpp.0.5.4.tar.gz"
+  sha256 "fd7c8085b3ecefeed43e194eb33cbb912b2bb9810e8f4eee2dcf21b606d19e35"
+  head "https://github.com/facebook/pathpicker.git"
+
+  # TODO -- add python2 requirement here (python3 coming soon)
+
+  def install
+    # we need to copy the bash file and source python files
+    libexec.install Dir["*"]
+    # and then symlink the bash file
+    bin.install_symlink libexec/"fpp"
+  end
+
+  test do
+    system bin/"fpp", "--help"
+  end
+end


### PR DESCRIPTION
Hey everyone! This is a port of the PathPicker recipe into linuxbrew for linux support. You can read more about PathPicker (`fpp` for short) here:
http://facebook.github.io/PathPicker/
https://github.com/facebook/pathpicker/

And can see the original homebrew PR here:
https://github.com/Homebrew/homebrew/pull/39324

The main thing I need help on is how to require the `python2` dependency. I tried to following the commit title that @tdsmith suggested from the original PR as well -- willing to keep this squashed and just in one commit.