### PR TITLE
Fix cgdb formula for linuxbrew.

### DIFF
--- a/Library/Formula/cgdb.rb
+++ b/Library/Formula/cgdb.rb
@@ -18,8 +18,13 @@ class Cgdb < Formula
     depends_on "automake" => :build
   end
 
+  if OS.linux?
+    depends_on "flex" => :build
+  end
   depends_on "help2man" => :build
   depends_on "readline"
+
+  patch :DATA
 
   def install
     system "sh", "autogen.sh" if build.head?
@@ -29,3 +34,15 @@ class Cgdb < Formula
     system "make install"
   end
 end
+__END__
+--- a/configure	2014-11-13 19:59:03.000000000 +0000
++++ b/configure	2015-05-27 13:04:58.815408757 +0000
+@@ -5443,7 +5443,7 @@ else
+   ac_cv_prog_HAS_HELP2MAN="$HAS_HELP2MAN" # Let the user override the test.
+ else
+ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+-for as_dir in path =$PATH
++for as_dir in $PATH
+ do
+   IFS=$as_save_IFS
+   test -z "$as_dir" && as_dir=.

--- a/Library/Formula/cgdb.rb
+++ b/Library/Formula/cgdb.rb
@@ -18,9 +18,7 @@ class Cgdb < Formula
     depends_on "automake" => :build
   end
 
-  if OS.linux?
-    depends_on "flex" => :build
-  end
+  depends_on "flex" => :build unless OS.mac?
   depends_on "help2man" => :build
   depends_on "readline"
 

--- a/Library/Formula/readline.rb
+++ b/Library/Formula/readline.rb
@@ -33,7 +33,7 @@ class Readline < Formula
 
   def install
     ENV.universal_binary
-    system "./configure", "--prefix=#{prefix}", "--enable-multibyte", ("--with-curses" if OS.linux?)
+    system "./configure", "--prefix=#{prefix}", "--enable-multibyte"
     system "make", "install"
 
     # The 6.3 release notes say:

--- a/Library/Formula/readline.rb
+++ b/Library/Formula/readline.rb
@@ -33,7 +33,7 @@ class Readline < Formula
 
   def install
     ENV.universal_binary
-    system "./configure", "--prefix=#{prefix}", "--enable-multibyte"
+    system "./configure", "--prefix=#{prefix}", "--enable-multibyte", ("--with-curses" if OS.linux?)
     system "make", "install"
 
     # The 6.3 release notes say:


### PR DESCRIPTION
Readline on Linux requires to be linked with appropriate version of NCurses.

As for cgdb it requires flex which may not be available for all distros. Also, its configure script contained an error which led to searching for help2man in incorrect paths (specifically: first directory from PATH variable was malformed).