### PR TITLE
Fix readline formula for linuxbrew by linking ncurses.

### DIFF
--- a/Library/Formula/readline.rb
+++ b/Library/Formula/readline.rb
@@ -33,6 +33,7 @@ class Readline < Formula
 
   def install
     ENV.universal_binary
+    # Add --with-curses to fix the error: CGDB requires GNU readline 5.1 or greater to link.
     system "./configure", "--prefix=#{prefix}", "--enable-multibyte", ("--with-curses" if OS.linux?)
     system "make", "install"
 

--- a/Library/Formula/readline.rb
+++ b/Library/Formula/readline.rb
@@ -33,7 +33,7 @@ class Readline < Formula
 
   def install
     ENV.universal_binary
-    system "./configure", "--prefix=#{prefix}", "--enable-multibyte"
+    system "./configure", "--prefix=#{prefix}", "--enable-multibyte", ("--with-curses" if OS.linux?)
     system "make", "install"
 
     # The 6.3 release notes say:


### PR DESCRIPTION
Readline builds and installs fine on Linux. However, when you install a dependent application (like cgdb) you might get a cryptic error message that configure is unable to check the version of readline. What actually happens is linker failing to find symbols from ncurses that should be linked with readline.

This PR fixes the issue.