### PR TITLE
qt build fix

### DIFF
--- a/Library/Formula/qt.rb
+++ b/Library/Formula/qt.rb
@@ -37,6 +37,7 @@ class Qt < Formula
 
   def install
     ENV.universal_binary if build.universal?
+    ENV["LD_LIBRARY_PATH"] = buildpath/"lib" if OS.linux?
 
     args = ["-prefix", prefix,
             "-system-zlib",


### PR DESCRIPTION
Fix issue where build script tries to link against (non-existant) system libQtCLucene.so.4, instead of the version in the source lib directory