### PR TITLE
Suggest installing unzip in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Paste at a Terminal prompt:
 ### Debian or Ubuntu
 
 ```sh
-sudo apt-get install build-essential curl git m4 ruby texinfo libbz2-dev libcurl4-openssl-dev libexpat-dev libncurses-dev zlib1g-dev
+sudo apt-get install build-essential curl git m4 ruby texinfo libbz2-dev libcurl4-openssl-dev libexpat-dev libncurses-dev unzip zlib1g-dev
 ```
 
 ### Fedora, CentOS or Red Hat
 
 ```sh
-sudo yum groupinstall 'Development Tools' && sudo yum install curl git irb m4 ruby texinfo bzip2-devel curl-devel expat-devel ncurses-devel zlib-devel
+sudo yum groupinstall 'Development Tools' && sudo yum install curl git irb m4 ruby texinfo bzip2-devel curl-devel expat-devel ncurses-devel unzip zlib-devel
 ```
 
 ### 32-bit x86 platforms


### PR DESCRIPTION
Zipped resources are unpacked with unzip. Failure to install unzip prior to running `brew install` may cause failures.