### PR TITLE
Add unzip as a dependency for zipped resources.

### DIFF
--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -189,6 +189,7 @@ class DependencyCollector
     when '.lz'  then Dependency.new('lzip', tags)
     when '.rar' then Dependency.new('unrar', tags)
     when '.7z'  then Dependency.new('p7zip', tags)
+    when '.zip' then Dependency.new('homebrew/dupes/unzip', tags) unless OS.mac?
     end
   end
 end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -145,6 +145,7 @@ end
 def with_system_path
   old_path = ENV['PATH']
   ENV['PATH'] = '/usr/bin:/bin'
+  ENV.prepend_path 'PATH', HOMEBREW_PREFIX/'bin' unless OS.mac?
   yield
 ensure
   ENV['PATH'] = old_path


### PR DESCRIPTION
For systems without unzip installed by default this ensures all resources can be handled properly.