### PR TITLE
libtool: Add symlink to libtool's old name

### DIFF
--- a/Library/Formula/libtool.rb
+++ b/Library/Formula/libtool.rb
@@ -27,6 +27,8 @@ class Libtool < Formula
                           ("--program-prefix=g" if build.without? "default-names"),
                           "--enable-ltdl-install"
     system "make", "install"
+    bin.install_symlink "libtool" => "glibtool"
+    bin.install_symlink "libtoolize" => "glibtoolize"
   end
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
 * Add symlink to `libtool`'s old name `glibtool`, because some other formula, like `autoconf`, is still expecting the `glibtool` binary.
 * For issue #453 