### PR TITLE
Fix bib-tool formula to work with Linuxbrew

### DIFF
--- a/Library/Formula/bib-tool.rb
+++ b/Library/Formula/bib-tool.rb
@@ -3,9 +3,13 @@
 # See https://github.com/Homebrew/homebrew/issues/40559
 class BibToolDownloadStrategy < CurlDownloadStrategy
   def stage
-     with_system_path { safe_system 'tar', 'xqf', cached_location, 'BibTool/doc/bibtool.tex' }
-     with_system_path { safe_system 'tar', 'xf', cached_location, '--exclude', 'BibTool/doc/bibtool.tex' }
-     chdir
+    if `tar --version`.match 'bsdtar'
+      with_system_path { safe_system 'tar', 'xqf', cached_location, 'BibTool/doc/bibtool.tex' }
+      with_system_path { safe_system 'tar', 'xf', cached_location, '--exclude', 'BibTool/doc/bibtool.tex' }
+    else
+      with_system_path { safe_system 'tar', 'xf', cached_location }
+    end
+    chdir
   end
 end
 


### PR DESCRIPTION
The tarball for v. 2.60 of BibTool has a problem where it contains a
duplicate file. This does not play nicely with bsdtar, which is what is
installed on Macs. See https://github.com/Homebrew/homebrew/issues/40559.

The commit that fixed that issue, however, made use of --fast-read (-q),
which is only implemented in bsdtar, not gnutar. In order to make sure
that this formula works with Linuxbrew, we need to define "stage" based
on the flavor of tar that is installed on the machine.

Closes #456.