### PR TITLE
python: hint dependencies

### DIFF
--- a/Library/Formula/python.rb
+++ b/Library/Formula/python.rb
@@ -94,7 +94,7 @@ class Python < Formula
     args << (OS.mac? ? "--enable-framework=#{frameworks}" : "--enable-shared")
     args << "--without-gcc" if ENV.compiler == :clang
 
-    unless MacOS::CLT.installed?
+    if OS.mac? && !MacOS::CLT.installed?
       # Help Python's build system (setuptools/pip) to build things on Xcode-only systems
       # The setup.py looks at "-isysroot" to get the sysroot (and not at --sysroot)
       cflags = "CFLAGS=-isysroot #{MacOS.sdk_path}"
@@ -106,6 +106,10 @@ class Python < Formula
       end
       args << cflags
       args << ldflags
+    elsif OS.linux?
+      cppflags = "CPPFLAGS=-I#{HOMEBREW_PREFIX}/include"
+      ldflags = "LDFLAGS=-L#{HOMEBREW_PREFIX}/lib"
+      args << cppflags << ldflags
     end
 
     # Avoid linking to libgcc https://code.activestate.com/lists/python-dev/112195/

--- a/Library/Formula/python.rb
+++ b/Library/Formula/python.rb
@@ -119,7 +119,7 @@ class Python < Formula
     # superenv handles that cc finds includes/libs!
     inreplace "setup.py" do |s|
       s.gsub! "do_readline = self.compiler.find_library_file(lib_dirs, 'readline')",
-              "do_readline = '#{Formula["readline"].opt_lib}/libhistory.dylib'"
+              "do_readline = '#{Formula["readline"].opt_lib}/libhistory.#{OS.mac? ? "dylib" : "so"}'"
       s.gsub! "/usr/local/ssl", Formula["openssl"].opt_prefix
     end
 

--- a/Library/Formula/python.rb
+++ b/Library/Formula/python.rb
@@ -28,6 +28,7 @@ class Python < Formula
   depends_on "gdbm" => :recommended
   depends_on "openssl"
   depends_on "homebrew/dupes/tcl-tk" => :optional
+  depends_on "homebrew/dupes/ncurses" => :recommended if OS.linux?
   depends_on :x11 if build.with?("tcl-tk") && Tab.for_name("homebrew/dupes/tcl-tk").with?("x11")
 
   skip_clean "bin/pip", "bin/pip-2.7"
@@ -108,6 +109,7 @@ class Python < Formula
       args << ldflags
     elsif OS.linux?
       cppflags = "CPPFLAGS=-I#{HOMEBREW_PREFIX}/include"
+      cppflags << " -I#{Formula["ncurses"].opt_include}/ncursesw" if build.with?("ncurses")
       ldflags = "LDFLAGS=-L#{HOMEBREW_PREFIX}/lib"
       args << cppflags << ldflags
     end

--- a/Library/Formula/python3.rb
+++ b/Library/Formula/python3.rb
@@ -100,7 +100,7 @@ class Python3 < Formula
     args << (OS.mac? ? "--enable-framework=#{frameworks}" : "--enable-shared")
     args << '--without-gcc' if ENV.compiler == :clang
 
-    unless MacOS::CLT.installed?
+    if OS.mac? && !MacOS::CLT.installed?
       # Help Python's build system (setuptools/pip) to build things on Xcode-only systems
       # The setup.py looks at "-isysroot" to get the sysroot (and not at --sysroot)
       cflags = "CFLAGS=-isysroot #{MacOS.sdk_path}"
@@ -111,7 +111,12 @@ class Python3 < Formula
       end
       args << cflags
       args << ldflags
+    elsif OS.linux?
+      cppflags = "CPPFLAGS=-I#{HOMEBREW_PREFIX}/include"
+      ldflags = "LDFLAGS=-L#{HOMEBREW_PREFIX}/lib"
+      args << cppflags << ldflags
     end
+
     # Avoid linking to libgcc http://code.activestate.com/lists/python-dev/112195/
     args << "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"
 

--- a/Library/Formula/python3.rb
+++ b/Library/Formula/python3.rb
@@ -32,6 +32,7 @@ class Python3 < Formula
   depends_on "openssl"
   depends_on "xz" => :recommended  # for the lzma module added in 3.3
   depends_on "homebrew/dupes/tcl-tk" => :optional
+  depends_on "homebrew/dupes/ncurses" => :recommended if OS.linux?
   depends_on :x11 if build.with? "tcl-tk" and Tab.for_name("homebrew/dupes/tcl-tk").with? "x11"
 
   skip_clean "bin/pip3", "bin/pip-3.4", "bin/pip-3.5"
@@ -113,6 +114,7 @@ class Python3 < Formula
       args << ldflags
     elsif OS.linux?
       cppflags = "CPPFLAGS=-I#{HOMEBREW_PREFIX}/include"
+      cppflags << " -I#{Formula["ncurses"].opt_include}/ncursesw" if build.with?("ncurses")
       ldflags = "LDFLAGS=-L#{HOMEBREW_PREFIX}/lib"
       args << cppflags << ldflags
     end

--- a/Library/Formula/python3.rb
+++ b/Library/Formula/python3.rb
@@ -124,7 +124,7 @@ class Python3 < Formula
     # superenv makes cc always find includes/libs!
     inreplace "setup.py" do |s|
       s.gsub! "do_readline = self.compiler.find_library_file(lib_dirs, 'readline')",
-              "do_readline = '#{Formula["readline"].opt_lib}/libhistory.dylib'"
+              "do_readline = '#{Formula["readline"].opt_lib}/libhistory.#{OS.mac? ? "dylib" : "so"}'"
       s.gsub! "/usr/local/ssl", Formula["openssl"].opt_prefix
     end
 


### PR DESCRIPTION
Add include paths to CPPFLAGS and library paths to LDFLAGS so extension modules find the Homebrew libraries on which they depend.

Fixes #420.

- [x] Test on Trusty
- [x] Test on CentOS 7
- [x] Apply symmetric change to python3.rb
- [x] Check whether `-I#{HOMEBREW_PREFIX}/include -L#{HOMEBREW_PREFIX}/lib` is sufficient