### PR TITLE
py2cairo 1.10.0: Fix for linuxbrew

### DIFF
--- a/Library/Formula/py2cairo.rb
+++ b/Library/Formula/py2cairo.rb
@@ -29,9 +29,9 @@ class Py2cairo < Formula
 
     # disable waf's python extension mode because it explicitly links libpython
     # https://code.google.com/p/waf/issues/detail?id=1531
-    inreplace "src/wscript", "pyext", ""
-    ENV["LINKFLAGS"] = "-undefined dynamic_lookup"
-    ENV.append_to_cflags `python-config --includes`
+    inreplace "src/wscript", "pyext", "" if OS.mac?
+    ENV["LINKFLAGS"] = "-undefined dynamic_lookup" if OS.mac?
+    ENV.append_to_cflags `python-config --includes` if OS.mac?
 
     # Python extensions default to universal but cairo may not be universal
     ENV["ARCHFLAGS"] = "-arch #{MacOS.preferred_arch}" unless build.universal?
@@ -40,7 +40,7 @@ class Py2cairo < Formula
     system "./waf", "install"
 
     module_dir = lib/"python2.7/site-packages/cairo"
-    mv module_dir/"lib_cairo.dylib", module_dir/"_cairo.so"
+    mv module_dir/"lib_cairo.dylib", module_dir/"_cairo.so" if OS.mac?
   end
 
   test do


### PR DESCRIPTION
Fix the error: No module _cairo can be found
The error is only triggered when the python module is used.