### PR TITLE
openssl 1.0.2c: fix for zlib

### DIFF
--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -21,7 +21,7 @@ class Openssl < Formula
   option "without-check", "Skip build-time tests (not recommended)"
 
   depends_on "makedepend" => :build
-  depends_on "zlib" unless OS.mac?
+  depends_on "homebrew/dupes/zlib" unless OS.mac?
 
   keg_only :provided_by_osx,
     "Apple has deprecated use of OpenSSL in favor of its own TLS and crypto libraries"


### PR DESCRIPTION
On a clean Ubuntu Trusty VM, when you try to install openssl, it gives `Error: No available formula for zlib (dependency of openssl)`.  I've updated it to point to the `dupes/zlib`.

To replicate the issue on a clean Ubuntu Trusty VM with vagrant:
```
vagrant init ubuntu/trusty64
vagrant up --provider virtualbox
vagrant ssh -c "sudo apt-get install -y build-essential curl git m4 ruby texinfo libbz2-dev libcurl4-openssl-dev libexpat-dev libncurses-dev zlib1g-dev"
vagrant ssh -c "git clone https://github.com/Homebrew/linuxbrew.git ~/.linuxbrew"
vagrant ssh -c "echo 'export PATH=\"\$HOME/.linuxbrew/bin:\$PATH\"' >> .bashrc"
```

```
vagrant ssh -c "sudo apt-get -y install gfortran"
vagrant ssh -c "ln -s \$(which gcc) ~/.linuxbrew/bin/gcc-4.8"
vagrant ssh -c "ln -s \$(which g++) ~/.linuxbrew/bin/g++-4.8"
vagrant ssh -c "ln -s \$(which gfortran) ~/.linuxbrew/bin/gfortran-4.8"
vagrant ssh -c "brew install openssl"
```