### PR TITLE
cmake depends on python on linux

### DIFF
--- a/Library/Formula/cmake.rb
+++ b/Library/Formula/cmake.rb
@@ -31,6 +31,7 @@ class Cmake < Formula
   option "without-docs", "Don't build man pages"
 
   depends_on :python => :build if OS.mac? && MacOS.version <= :snow_leopard && build.with?("docs")
+  depends_on :python => :build if OS.linux?
   depends_on "curl" unless OS.mac?
 
   # The `with-qt` GUI option was removed due to circular dependencies if


### PR DESCRIPTION
I'm installing rust using linuxbrew on a new system that does not have python. It fails to build cmake since cmake is not bottled for this system and its python build dependency does not apply to linux. I added an explicit python dependency on linux. 

Will this respect a system-installed python as satisfying the dependency?