### PR TITLE
emacs: add libxml2 compile option

### DIFF
--- a/Library/Formula/emacs.rb
+++ b/Library/Formula/emacs.rb
@@ -26,6 +26,7 @@ class Emacs < Formula
 
   option "with-cocoa", "Build a Cocoa version of emacs"
   option "with-ctags", "Don't remove the ctags executable that emacs provides"
+  option "without-libxml2", "Don't build with libxml2 support"
 
   deprecated_option "cocoa" => "with-cocoa"
   deprecated_option "keep-ctags" => "with-ctags"
@@ -39,6 +40,7 @@ class Emacs < Formula
   depends_on "imagemagick" => :optional
   depends_on "mailutils" => :optional
   depends_on "glib" => :optional
+  depends_on "libxml2" unless OS.mac?
 
   # https://github.com/Homebrew/homebrew/issues/37803
   if build.with? "x11"
@@ -57,6 +59,12 @@ class Emacs < Formula
             "--infodir=#{info}/emacs"]
 
     args << "--with-file-notification=gfile" if build.with? "glib"
+
+    if build.with? "libxml2"
+      args << "--with-xml2"
+    else
+      args << "--without-xml2"
+    end
 
     if build.with? "d-bus"
       args << "--with-dbus"


### PR DESCRIPTION
This was mostly pattern matching to the other options and a bit reading up on formulae as this is the first time I have touched one of those. 

Sorry if I didn't get it right, I'm happy to fix if it needs fixing - but it works fine for me and I can now use eww in emacs.