### PR TITLE
Implement a :blas dependency

### DIFF
--- a/Library/Formula/blastest.rb
+++ b/Library/Formula/blastest.rb
@@ -1,0 +1,18 @@
+class Blastest < Formula
+  desc "blas test"
+  homepage "https://tds.xyz"
+  url "https://gist.githubusercontent.com/tdsmith/345b08bb656ad54c1701/raw/c0d4e2b1362d43dad0760bcc1ec24e4b881683ef/blastest.c"
+  sha256 "ea6a083d6bccbc94e503f00911e9abedb5e1b3a0ed80ad1e5077b80fd6f36b42"
+  version "1.0"
+
+  depends_on :blas if OS.linux?
+
+  def install
+    system "#{ENV.cc} blastest.c #{ENV["HOMEBREW_BLAS_CFLAGS"]} -o blastest #{ENV["HOMEBREW_BLAS_LDFLAGS"]}"
+    bin.install "blastest"
+  end
+
+  test do
+    system bin/"blastest"
+  end
+end

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -126,6 +126,8 @@ class DependencyCollector
       Dependency.new("libtool", tags)
     when :python2
       PythonRequirement.new(tags)
+    when :blas
+      BlasRequirement.new(tags)
     else
       raise ArgumentError, "Unsupported special dependency #{spec.inspect}"
     end

--- a/Library/Homebrew/requirements.rb
+++ b/Library/Homebrew/requirements.rb
@@ -1,5 +1,6 @@
 require "requirement"
 require "requirements/apr_requirement"
+require "requirements/blas_requirement"
 require "requirements/fortran_requirement"
 require "requirements/language_module_requirement"
 require "requirements/minimum_macos_requirement"

--- a/Library/Homebrew/requirements/blas_requirement.rb
+++ b/Library/Homebrew/requirements/blas_requirement.rb
@@ -1,0 +1,47 @@
+require "requirement"
+
+class BlasRequirement < Requirement
+  fatal true
+  default_formula "openblas"
+
+  # This ensures that HOMEBREW_BLAS_CFLAGS and HOMEBREW_BLAS_LDFLAGS
+  # are always set. It does _not_ add them to CFLAGS or LDFLAGS; that
+  # should happen inside the formula.
+  env do
+    if @satisfied_result
+      ENV["HOMEBREW_BLAS_CFLAGS"] ||= ""
+      ENV["HOMEBREW_BLAS_LDFLAGS"] ||= "-lblas -llapack"
+    else
+      ENV["HOMEBREW_BLAS_CFLAGS"] = "-I#{Formula["openblas"].opt_include}"
+      ENV["HOMEBREW_BLAS_LDFLAGS"] = "-L#{Formula["openblas"].opt_lib} -lopenblas"
+    end
+  end
+
+  satisfy :build_env => true do
+    cflags = ENV["HOMEBREW_BLAS_CFLAGS"] || ""
+    ldflags = ENV["HOMEBREW_BLAS_LDFLAGS"] || "-lblas -llapack"
+    success = nil
+    Dir.mktmpdir do |tmpdir|
+      tmpdir = Pathname.new tmpdir
+      (tmpdir/"blastest.c").write <<-EOS.undent
+        double cblas_ddot(const int, const double*, const int, const double*, const int);
+        int main() {
+          double x[] = {1.0, 2.0, 3.0}, y[] = {4.0, 5.0, 6.0};
+          cblas_ddot(3, x, 1, y, 1);
+          return 0;
+        }
+      EOS
+      success = system "#{ENV["CC"]} #{cflags} #{tmpdir}/blastest.c -o #{tmpdir}/blastest #{ldflags}",
+                :err => "/dev/null"
+    end
+    if !success
+      opoo "BLAS not configured"
+      puts <<-EOS.undent
+        Falling back to brewed openblas. If you prefer to use a system BLAS,
+        please set HOMEBREW_BLAS_CFLAGS and HOMEBREW_BLAS_LDFLAGS to correct
+        values.
+      EOS
+    end
+    success
+  end
+end


### PR DESCRIPTION
Example output with no system BLAS:

```
vagrant@vagrant-ubuntu-trusty-64:~$ brew install blastest
Warning: BLAS not configured
Falling back to brewed openblas. If you prefer to use a system BLAS,
please set HOMEBREW_BLAS_CFLAGS and HOMEBREW_BLAS_LDFLAGS to correct
values.
Warning: BLAS not configured
Falling back to brewed openblas. If you prefer to use a system BLAS,
please set HOMEBREW_BLAS_CFLAGS and HOMEBREW_BLAS_LDFLAGS to correct
values.
==> Downloading https://gist.githubusercontent.com/tdsmith/345b08bb656ad54c1701/raw/c0d4e2b1362d43dad0760bcc1ec24e4b881683ef/blastest.c
Already downloaded: /home/vagrant/.cache/Homebrew/blastest-1.0.c
==> /usr/bin/gcc-4.8 blastest.c -I/home/vagrant/.linuxbrew/opt/openblas/include -o blastest -L/home/vagrant/.linuxbrew/opt/openblas/lib -lopenb
/home/vagrant/.linuxbrew/Cellar/blastest/1.0: 2 files, 24K, built in 2 seconds

vagrant@vagrant-ubuntu-trusty-64:~$ ldd /home/vagrant/.linuxbrew/Cellar/blastest/1.0/bin/blastest
	linux-vdso.so.1 =>  (0x00007ffcee7a7000)
	libopenblas.so.0 => /home/vagrant/.linuxbrew/lib/libopenblas.so.0 (0x00007fdac8038000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fdac7c6c000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fdac7965000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fdac7747000)
	libgfortran.so.3 => /usr/lib/x86_64-linux-gnu/libgfortran.so.3 (0x00007fdac742d000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fdac8eb7000)
	libquadmath.so.0 => /usr/lib/x86_64-linux-gnu/libquadmath.so.0 (0x00007fdac71f0000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fdac6fda000)
```

With a system BLAS:
```
vagrant@vagrant-ubuntu-trusty-64:~$ sudo apt-get install libblas-dev liblapack-dev
vagrant@vagrant-ubuntu-trusty-64:~$ brew reinstall blastest
==> Reinstalling blastest
==> Downloading https://gist.githubusercontent.com/tdsmith/345b08bb656ad54c1701/raw/c0d4e2b1362d43dad0760bcc1ec24e4b881683ef/blastest.c
Already downloaded: /home/vagrant/.cache/Homebrew/blastest-1.0.c
==> /usr/bin/gcc-4.8 blastest.c  -o blastest -lblas -llapack
/home/vagrant/.linuxbrew/Cellar/blastest/1.0: 2 files, 24K, built in 2 seconds

vagrant@vagrant-ubuntu-trusty-64:~$ ldd /home/vagrant/.linuxbrew/Cellar/blastest/1.0/bin/blastest
	linux-vdso.so.1 =>  (0x00007fff3cbfd000)
	libblas.so.3 => /usr/lib/libblas.so.3 (0x00007f0653dc9000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f0653a04000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f06536fd000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f065404f000)
```

Setting HOMEBREW_BLAS_CFLAGS and HOMEBREW_BLAS_LDFLAGS propagates:

```
vagrant@vagrant-ubuntu-trusty-64:~$ HOMEBREW_BLAS_CFLAGS="-I/tmp" HOMEBREW_BLAS_LDFLAGS="-lblas -llapack -lm" brew reinstall blastest
==> Reinstalling blastest
==> Downloading https://gist.githubusercontent.com/tdsmith/345b08bb656ad54c1701/raw/c0d4e2b1362d43dad0760bcc1ec24e4b881683ef/blastest.c
Already downloaded: /home/vagrant/.cache/Homebrew/blastest-1.0.c
==> /usr/bin/gcc-4.8 blastest.c -I/tmp -o blastest -lblas -llapack -lm
/home/vagrant/.linuxbrew/Cellar/blastest/1.0: 2 files, 24K, built in 2 seconds
```

This needs documentation (where?) and the warning message could probably be friendlier. It gets printed a couple times but I don't think that's easy to influence.