### PR TITLE
FIXED: openssl fails to build on a raspberry pi

### DIFF
--- a/Library/Homebrew/os/linux/hardware.rb
+++ b/Library/Homebrew/os/linux/hardware.rb
@@ -50,7 +50,13 @@ module LinuxCPUs
   end
 
   def flags
-    @flags ||= cpuinfo[/^flags.*/, 0].split
+    f = cpuinfo[/^flags.*/, 0]
+
+    if f.nil?
+      @flags ||= []
+    else
+      @flags ||= cpuinfo[/^flags.*/, 0].split
+    end
   end
 
   # Compatibility with Mac method, which returns lowercase symbols


### PR DESCRIPTION
Quick & dirty fix but it got the job done. Feel free to improve it.

**Details:**
I was trying to build openssl on a Raspberry Pi 2

I ran this command:

    brew install --verbose openssl

And got the following output:

>==> Downloading https://www.openssl.org/source/openssl-1.0.2d.tar.gz
/usr/bin/curl -fLA Homebrew 0.9.5 (Ruby 1.9.3-194; arm-linux-eabihf) https://www.openssl.org/source/openssl-1.0.2d.tar.gz -C 0 -o /home/pi/.cache/Homebrew/openssl-1.0.2d.tar.gz.incomplete --connect-timeout 5
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 5171k  100 5171k    0     0  3431k      0  0:00:01  0:00:01 --:--:-- 3581k
==> Verifying openssl-1.0.2d.tar.gz checksum
tar xf /home/pi/.cache/Homebrew/openssl-1.0.2d.tar.gz
tar: A lone zero block at 52140
Error: undefined method `split' for nil:NilClass
Please report this bug:
    https://github.com/Homebrew/linuxbrew/blob/master/share/doc/homebrew/Troubleshooting.md#troubleshooting
/home/pi/.linuxbrew/Library/Homebrew/os/linux/hardware.rb:53:in `flags'
/home/pi/.linuxbrew/Library/Homebrew/os/linux/hardware.rb:63:in `block (2 levels) in <module:LinuxCPUs>'
/home/pi/.linuxbrew/Library/Homebrew/os/mac.rb:171:in `prefer_64_bit?'
/home/pi/.linuxbrew/Library/Formula/openssl.rb:53:in `install'
/home/pi/.linuxbrew/Library/Homebrew/build.rb:129:in `block in install'
/home/pi/.linuxbrew/Library/Homebrew/formula.rb:666:in `block in brew'
/home/pi/.linuxbrew/Library/Homebrew/formula.rb:1076:in `block in stage'
/home/pi/.linuxbrew/Library/Homebrew/resource.rb:91:in `block in unpack'
/home/pi/.linuxbrew/Library/Homebrew/extend/fileutils.rb:16:in `mktemp'
/home/pi/.linuxbrew/Library/Homebrew/resource.rb:88:in `unpack'
/home/pi/.linuxbrew/Library/Homebrew/resource.rb:81:in `stage'
/home/pi/.linuxbrew/Library/Homebrew/formula.rb:1068:in `stage'
/home/pi/.linuxbrew/Library/Homebrew/formula.rb:662:in `brew'
/home/pi/.linuxbrew/Library/Homebrew/build.rb:107:in `install'
/home/pi/.linuxbrew/Library/Homebrew/build.rb:179:in `<main>'

After investigating a little, I found out that the error was caused by the fact my _/proc/cpuinfo_ file didn't have any line begining with `flags.`:

> processor	: 0
model name	: ARMv7 Processor rev 5 (v7l)
BogoMIPS	: 57.60
Features	: half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm
CPU implementer	: 0x41
CPU architecture: 7
CPU variant	: 0x0
CPU part	: 0xc07
CPU revision	: 5
>
>processor	: 1
model name	: ARMv7 Processor rev 5 (v7l)
BogoMIPS	: 57.60
Features	: half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm
CPU implementer	: 0x41
CPU architecture: 7
CPU variant	: 0x0
CPU part	: 0xc07
CPU revision	: 5
>
>processor	: 2
model name	: ARMv7 Processor rev 5 (v7l)
BogoMIPS	: 57.60
Features	: half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm
CPU implementer	: 0x41
CPU architecture: 7
CPU variant	: 0x0
CPU part	: 0xc07
CPU revision	: 5
>
>processor	: 3
model name	: ARMv7 Processor rev 5 (v7l)
BogoMIPS	: 57.60
Features	: half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm
CPU implementer	: 0x41
CPU architecture: 7
CPU variant	: 0x0
CPU part	: 0xc07
CPU revision	: 5
>
>Hardware	: BCM2709
Revision	: a01041
Serial		: 000000006cd23207