### PR TITLE
Tor formula fixed for linux

### DIFF
--- a/Library/Formula/tor.rb
+++ b/Library/Formula/tor.rb
@@ -31,6 +31,7 @@ class Tor < Formula
       --prefix=#{prefix}
       --sysconfdir=#{etc}
       --with-openssl-dir=#{Formula["openssl"].opt_prefix}
+      --with-libevent-dir=#{Formula["libevent"].opt_prefix}
     ]
 
     args << "--with-libnatpmp-dir=#{Formula["libnatpmp"].opt_prefix}" if build.with? "libnatpmp"


### PR DESCRIPTION
Fixes the tor formula for Linux (libevent wasn't found by the `./configure` script).
Tested on a Raspberry Pi 2 and a Macbook running OS X 10.10.5 beta.