### PR TITLE
Provide empty cpu flags for arm processor

### DIFF
--- a/Library/Homebrew/os/linux/hardware.rb
+++ b/Library/Homebrew/os/linux/hardware.rb
@@ -50,7 +50,11 @@ module LinuxCPUs
   end
 
   def flags
-    @flags ||= cpuinfo[/^flags.*/, 0].split
+    if intel?
+      @flags ||= cpuinfo[/^flags.*/, 0].split
+    elsif arm?
+      []
+    end
   end
 
   # Compatibility with Mac method, which returns lowercase symbols


### PR DESCRIPTION
With arm processor (at least Raspberry Pi 2), there is no line in /proc/cpuinfo
that starts with "flags".  `brew install readline` will crash on line 53 of linuxbrew/Library/Homebrew/os/linux/hardware.rb
Provide an empty list of flags instead.
```
arch_pi% cat /proc/cpuinfo
processor	: 0
model name	: ARMv7 Processor rev 5 (v7l)
BogoMIPS	: 38.40
Features	: half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm 
CPU implementer	: 0x41
CPU architecture: 7
CPU variant	: 0x0
CPU part	: 0xc07
CPU revision	: 5

processor	: 1
model name	: ARMv7 Processor rev 5 (v7l)
BogoMIPS	: 38.40
Features	: half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm 
CPU implementer	: 0x41
CPU architecture: 7
CPU variant	: 0x0
CPU part	: 0xc07
CPU revision	: 5

processor	: 2
model name	: ARMv7 Processor rev 5 (v7l)
BogoMIPS	: 38.40
Features	: half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm 
CPU implementer	: 0x41
CPU architecture: 7
CPU variant	: 0x0
CPU part	: 0xc07
CPU revision	: 5

processor	: 3
model name	: ARMv7 Processor rev 5 (v7l)
BogoMIPS	: 38.40
Features	: half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm 
CPU implementer	: 0x41
CPU architecture: 7
CPU variant	: 0x0
CPU part	: 0xc07
CPU revision	: 5

Hardware	: BCM2709
Revision	: a21041
Serial		: 00000000c59cfa3a
```