### PR TITLE
Implement a :cmake dependency

### DIFF
--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -114,6 +114,7 @@ class DependencyCollector
     when :ant        then ant_dep(spec, tags)
     when :apr        then AprRequirement.new(tags)
     when :emacs      then EmacsRequirement.new(tags)
+    when :cmake      then CmakeRequirement.new(tags)
     # Tiger's ld is too old to properly link some software
     when :ld64       then LD64Dependency.new if MacOS.version < :leopard
     when :clt # deprecated

--- a/Library/Homebrew/requirements.rb
+++ b/Library/Homebrew/requirements.rb
@@ -1,5 +1,6 @@
 require "requirement"
 require "requirements/apr_requirement"
+require "requirements/cmake_requirement"
 require "requirements/fortran_requirement"
 require "requirements/language_module_requirement"
 require "requirements/minimum_macos_requirement"

--- a/Library/Homebrew/requirements/cmake_requirement.rb
+++ b/Library/Homebrew/requirements/cmake_requirement.rb
@@ -1,0 +1,36 @@
+require "requirement"
+
+class CmakeRequirement < Requirement
+  fatal true
+  default_formula "cmake"
+
+  def initialize(tags)
+    @version = tags.shift if /\d+\.*\d*/ === tags.first
+    raise "Specify a version for CmakeRequirement" unless @version
+    super
+  end
+
+  satisfy :build_env => false do
+    next unless which "cmake"
+    cmake_version = Utils.popen_read("cmake", "--version")
+    words = cmake_version.split(" ")
+    cmake_version = words.last
+    # debug:
+    ohai "cmake_version: #{cmake_version} vs #{@version}"
+    Version.new(cmake_version) >= Version.new(@version)
+  end
+
+  env do
+    ENV.prepend_path "PATH", which("cmake").dirname
+  end
+
+  def message
+    s = "Cmake #{@version} or later is required."
+    s += super
+    s
+  end
+
+  def inspect
+    "#<#{self.class.name}: #{name.inspect} #{tags.inspect} version=#{@version.inspect}>"
+  end
+end

--- a/Library/Homebrew/requirements/cmake_requirement.rb
+++ b/Library/Homebrew/requirements/cmake_requirement.rb
@@ -12,11 +12,7 @@ class CmakeRequirement < Requirement
 
   satisfy :build_env => false do
     next unless which "cmake"
-    cmake_version = Utils.popen_read("cmake", "--version")
-    words = cmake_version.split(" ")
-    cmake_version = words.last
-    # debug:
-    ohai "cmake_version: #{cmake_version} vs #{@version}"
+    cmake_version = Utils.popen_read("cmake", "--version").split(" ").last
     Version.new(cmake_version) >= Version.new(@version)
   end
 

--- a/Library/Homebrew/requirements/cmake_requirement.rb
+++ b/Library/Homebrew/requirements/cmake_requirement.rb
@@ -17,7 +17,9 @@ class CmakeRequirement < Requirement
   end
 
   env do
-    ENV.prepend_path "PATH", which("cmake").dirname
+    # do append_path to avoid messing up with isolated build
+    # envirnoment when cmake is located in /usr/bin/ and alike
+    ENV.append_path "PATH", which("cmake").dirname
   end
 
   def message


### PR DESCRIPTION
the rationale is to avoid installing (and possibly failing while doing so) a big number of dependencies when `cmake` is available on the target system. Essentially similar to `:mpi`.

~~This is work in progress (inspired by `:emacs` dependency). I certainly parse versions correctly but i think something is wrong in the comparision as if a test formula needs cmake `2.7` and `2.8.12.2` is available, the linuxbrew `cmake` build is still triggered...~~

related PR: https://github.com/Homebrew/linuxbrew/pull/511
partly addresses the issue: https://github.com/Homebrew/linuxbrew/issues/504