### PR TITLE
[WIP] allow full path in HOMEBREW_CC

### DIFF
--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -1,6 +1,6 @@
 module CompilerConstants
   GNU_GCC_VERSIONS = %w[4.3 4.4 4.5 4.6 4.7 4.8 4.9 5]
-  GNU_GCC_REGEXP = /^gcc-(4\.[3-9]|5)$/
+  GNU_GCC_REGEXP = /(?:[^\/]*)gcc-(4\.[3-9]|5)$/
   COMPILER_SYMBOL_MAP = {
     "gcc-4.0"  => :gcc_4_0,
     (OS.mac? ? "gcc-4.2" : "gcc") => :gcc,


### PR DESCRIPTION
this is work in progress. So far I changed regex to allow full path and still catch up version in the first group. This seemed to be working if

*  i do `brew tap homebrew/versions`

It is unfortunate that one needs to tap versions just to pass some internal checks. Without that it fails on 
https://github.com/Homebrew/linuxbrew/blob/master/Library/Homebrew/extend/ENV/shared.rb#L138
I suppose this could be avoided if one checks existence of executable in `HOMEBREW_CC` and using this decide between requiring `homebrew/versions` or not.

It could be a good idea to modify regex to allow something like `/apps/gcc/4.8.2/bin/gcc`, i.e. `(?:[^\/]*)(?:gcc-|\/)(4\.[3-9]|5)(?:$|\/gcc$)`. That would certainly make it more robust. But I understand that `c++` compiler is inferred from cc, so this should also be changed.

p.s. this should address https://github.com/Homebrew/linuxbrew/issues/548

- [ ]  `GNU_GCC_VERSIONS` should include `5.1` and `5.2`, i think
- [ ] make regex more flexible.
- [ ] do not require `brew tap homebrew/versions`
