### PR TITLE
qt (add to caveat)

### DIFF
--- a/Library/Formula/qt.rb
+++ b/Library/Formula/qt.rb
@@ -114,6 +114,9 @@ class Qt < Formula
   def caveats; <<-EOS.undent
     We agreed to the Qt opensource license for you.
     If this is unacceptable you should uninstall.
+
+    The following packages have to be installed:
+      sudo apt-get install libfontconfig1-dev libfreetype6-dev libx11-dev libxcursor-dev libxext-dev libxfixes-dev libxft-dev libxft-dev libxi-dev libxrandr-dev libxrender-dev
     EOS
   end
 end


### PR DESCRIPTION
without those packages:
```
Basic XLib functionality test failed!
 You might need to modify the include and library search paths by editing
 QMAKE_INCDIR_X11 and QMAKE_LIBDIR_X11 in /home/davydden/Library/Temp/qt20150917-1700-1na8nib/qt-everywhere-opensource-src-4.8.7/mkspecs/linux-g++.
```