### PR TITLE
boost: Add the Homebrew library path in linkflags

### DIFF
--- a/Library/Formula/boost.rb
+++ b/Library/Formula/boost.rb
@@ -125,10 +125,10 @@ class Boost < Formula
     end
 
     # Fix error: bzlib.h: No such file or directory
+    #            cannot find -lbz2
     args += [
       "include=#{HOMEBREW_PREFIX}/include",
-      "cflags=-L#{HOMEBREW_PREFIX}/lib",
-      "cxxflags=-L#{HOMEBREW_PREFIX}/lib"] unless OS.mac?
+      "linkflags=-L#{HOMEBREW_PREFIX}/lib"] unless OS.mac?
 
     system "./bootstrap.sh", *bootstrap_args
     system "./b2", *args


### PR DESCRIPTION
In my case 9a98daf (cf. #322) was not enough, and I got linker errors during making shared libraries (libboost_iostreams-mt.so.1.58.0 and libboost_iostreams.so.1.58.0):

```
/usr/bin/ld: cannot find -lbz2
```

This patch makes b2 program use the correct Homebrew library path.