### PR TITLE
pmd: Use unzip instead of tar to extract on Linux

### DIFF
--- a/Library/Formula/pmd.rb
+++ b/Library/Formula/pmd.rb
@@ -12,7 +12,10 @@ class Pmd < Formula
     doc.install "LICENSE", "NOTICE", "README.md"
 
     # The mvn package target produces a .zip with all the jars needed for PMD
-    safe_system "tar", "-xf", buildpath/"pmd-dist/target/pmd-bin-#{version}.zip"
+    path = buildpath/"pmd-dist/target/pmd-bin-#{version}.zip"
+    safe_system "unzip", path if OS.linux?
+    safe_system "tar", "-xf", path if OS.mac?
+
     libexec.install "pmd-bin-#{version}/bin", "pmd-bin-#{version}/lib"
 
     bin.install_symlink "#{libexec}/bin/run.sh" => "pmd"


### PR DESCRIPTION
The PMD formula previously used tar(1) to extract the zip archive. This works
fine on Macs, because BSD's tar can handle zip archives. GNU tar can't, so as
of this commit we use unzip(1) instead.

By the way, happy hacktoberfest! https://hacktoberfest.digitalocean.com/
