### PR TITLE
[WIP] append to LD_LIBRARY_PATH formula.lib

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -40,6 +40,13 @@ module Stdenv
       # /usr/local is already an -isystem and -L directory so we skip it
       self["CPPFLAGS"] = "-isystem#{HOMEBREW_PREFIX}/include"
       self["LDFLAGS"] = "-L#{HOMEBREW_PREFIX}/lib"
+      # software like Netcdf are built in several steps.
+      # In a single step one may need to link against the library build
+      # in the previous step. To make it work do:
+      ohai "Formula: #{formula}"
+      ohai "Formula lib: #{formula.lib}" if formula != nil
+      append "LD_LIBRARY_PATH", "-L#{formula.lib}" if formula != nil
+      ohai "#{ENV["LD_LIBRARY_PATH"]}"
       # CMake ignores the variables above
       self["CMAKE_PREFIX_PATH"] = HOMEBREW_PREFIX.to_s
     end


### PR DESCRIPTION
tries to fix https://github.com/Homebrew/homebrew-science/issues/2521

I do append to `LD_LIBRARY_PATH`, but netcdf still fails :(

What works **inside** Netcdf is
```
if build.with? "fortran"
  resource("fortran").stage do
        ENV.prepend "LD_LIBRARY_PATH", "#{lib}" # <=============
        system "./configure", *common_args
        system "make"
        system "make", "check" if build.with? "check"
        system "make", "install"
  end
end
```

could that be related to `resource()` usage?