### PR TITLE
Add libxslt dependency for gnome-doc-utils.

### DIFF
--- a/Library/Formula/gnome-doc-utils.rb
+++ b/Library/Formula/gnome-doc-utils.rb
@@ -17,6 +17,7 @@ class GnomeDocUtils < Formula
   depends_on "docbook"
   depends_on "gettext"
   depends_on "libxml2" => "with-python"
+  depends_on "libxslt" unless OS.mac?
 
   fails_with :llvm do
     build 2326


### PR DESCRIPTION
Helps for

```
==> ./configure --prefix=/home/linuxbrew/.linuxbrew/Cellar/gnome-doc-utils/0.20.10 --disable-scrollkeeper --enable-build-utils=yes
Last 15 lines from /home/linuxbrew/.cache/Homebrew/Logs/gnome-doc-utils/01.configure:
checking pkg-config is at least version 0.9.0... yes
checking for GNOME_DOC_UTILS... no
configure: error: Package requirements (
        libxml-2.0 >= 2.6.12
        libxslt    >= 1.1.8
) were not met:

No package 'libxslt' found

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.

Alternatively, you may set the environment variables GNOME_DOC_UTILS_CFLAGS
and GNOME_DOC_UTILS_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.
```