### PR TITLE
dirmngr: Add openldap dependency

### DIFF
--- a/Library/Formula/dirmngr.rb
+++ b/Library/Formula/dirmngr.rb
@@ -19,6 +19,7 @@ class Dirmngr < Formula
   depends_on "libgcrypt"
   depends_on "libksba"
   depends_on "pth"
+  depends_on "homebrew/dupes/openldap" unless OS.mac?
 
   patch :p0 do
     # patch by upstream developer to fix an API incompatibility with libgcrypt >=1.6.0


### PR DESCRIPTION
Cures

```
==> ./configure --prefix=/home/linuxbrew/.linuxbrew/Cellar/dirmngr/1.1.1_1 --sysconfdir=/home/linuxbrew/.linuxbrew/etc
Last 15 lines from /home/linuxbrew/.cache/Homebrew/Logs/dirmngr/01.configure:
checking for strtoull... yes
checking for mmap... yes
checking for canonicalize_file_name... yes
configure:
***
*** You need a LDAP library to build this program.
*** Check out
***    http://www.openldap.org
*** for a suitable implementation.
***
configure: error: 
***
*** Required libraries not found. Please consult the above messages
*** and install them before running configure again.
***
```