### PR TITLE
Add libxml dependency for libsoup.

### DIFF
--- a/Library/Formula/libsoup.rb
+++ b/Library/Formula/libsoup.rb
@@ -17,6 +17,7 @@ class Libsoup < Formula
   depends_on "sqlite"
   depends_on "gobject-introspection"
   depends_on "vala"
+  depends_on "libxml2" unless OS.mac?
 
   def install
     args = [


### PR DESCRIPTION
Helps for

```
==> ./configure --disable-silent-rules --prefix=/home/linuxbrew/.linuxbrew/Cellar/libsoup/2.52.0 --without-gnome --disable-tls-check
Last 15 lines from /home/linuxbrew/.cache/Homebrew/Logs/libsoup/01.configure:
checking whether to build static libraries... yes
checking for pkg-config... /home/linuxbrew/.linuxbrew/bin/pkg-config
checking pkg-config is at least version 0.16... yes
checking for GLIB - version >= 2.38.0... yes (version 2.46.0)
checking for XML... no
configure: error: Package requirements (libxml-2.0) were not met:

No package 'libxml-2.0' found

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.

Alternatively, you may set the environment variables XML_CFLAGS
and XML_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.
```