### PR TITLE
Blas dependency (updated)

### DIFF
--- a/Library/Formula/blastest.rb
+++ b/Library/Formula/blastest.rb
@@ -1,0 +1,18 @@
+class Blastest < Formula
+  desc "blas test"
+  homepage "https://tds.xyz"
+  url "https://gist.githubusercontent.com/tdsmith/345b08bb656ad54c1701/raw/c0d4e2b1362d43dad0760bcc1ec24e4b881683ef/blastest.c"
+  sha256 "ea6a083d6bccbc94e503f00911e9abedb5e1b3a0ed80ad1e5077b80fd6f36b42"
+  version "1.0"
+
+  depends_on :blas if OS.linux?
+
+  def install
+    system "#{ENV.cc} blastest.c #{ENV["HOMEBREW_BLAS_CFLAGS"]} -o blastest #{ENV["HOMEBREW_BLAS_LDFLAGS"]}"
+    bin.install "blastest"
+  end
+
+  test do
+    system bin/"blastest"
+  end
+end

--- a/Library/Formula/blastest.rb
+++ b/Library/Formula/blastest.rb
@@ -8,13 +8,9 @@ class Blastest < Formula
   depends_on :blas
 
   def install
-    blas_names = ENV["HOMEBREW_BLASLAPACK_NAMES"]
-    blas_lib   = ENV["HOMEBREW_BLASLAPACK_LIB"]
-    blas_inc   = ENV["HOMEBREW_BLASLAPACK_INC"]
-    ldflags    = blas_lib != "" ? "-L#{blas_lib} " : ""
-    ldflags   += blas_names.split(";").map { |word| "-l#{word}" }.join(" ")
+    ldflags    = BlasRequirement.ldflags(ENV["HOMEBREW_BLASLAPACK_LIB"],ENV["HOMEBREW_BLASLAPACK_NAMES"])
     ldflags   += " -pthread -lm"
-    cflags     = blas_inc != "" ? "-I#{blas_inc}"  : ""
+    cflags     = BlasRequirement.cflags(ENV["HOMEBREW_BLASLAPACK_INC"])
     system "#{ENV.cc} blastest.c #{cflags} -o blastest #{ldflags}"
     bin.install "blastest"
   end

--- a/Library/Formula/blastest.rb
+++ b/Library/Formula/blastest.rb
@@ -5,10 +5,17 @@ class Blastest < Formula
   sha256 "ea6a083d6bccbc94e503f00911e9abedb5e1b3a0ed80ad1e5077b80fd6f36b42"
   version "1.0"
 
-  depends_on :blas if OS.linux?
+  depends_on :blas
 
   def install
-    system "#{ENV.cc} blastest.c #{ENV["HOMEBREW_BLAS_CFLAGS"]} -o blastest #{ENV["HOMEBREW_BLAS_LDFLAGS"]}"
+    blas_names = ENV["HOMEBREW_BLASLAPACK_NAMES"]
+    blas_lib   = ENV["HOMEBREW_BLASLAPACK_LIB"]
+    blas_inc   = ENV["HOMEBREW_BLASLAPACK_INC"]
+    ldflags    = blas_lib != "" ? "-L#{blas_lib} " : ""
+    ldflags   += blas_names.split(";").map { |word| "-l#{word}" }.join(" ")
+    ldflags   += " -pthread -lm"
+    cflags     = blas_inc != "" ? "-I#{blas_inc}"  : ""
+    system "#{ENV.cc} blastest.c #{cflags} -o blastest #{ldflags}"
     bin.install "blastest"
   end
 

--- a/Library/Formula/blastest.rb
+++ b/Library/Formula/blastest.rb
@@ -11,6 +11,7 @@ class Blastest < Formula
     ldflags    = BlasRequirement.ldflags(ENV["HOMEBREW_BLASLAPACK_LIB"],ENV["HOMEBREW_BLASLAPACK_NAMES"])
     ldflags   += " -pthread -lm"
     cflags     = BlasRequirement.cflags(ENV["HOMEBREW_BLASLAPACK_INC"])
+    ohai "Full path: " + BlasRequirement.full_path(ENV["HOMEBREW_BLASLAPACK_LIB"],ENV["HOMEBREW_BLASLAPACK_NAMES"],";")
     system "#{ENV.cc} blastest.c #{cflags} -o blastest #{ldflags}"
     bin.install "blastest"
   end

--- a/Library/Formula/blastest_single.rb
+++ b/Library/Formula/blastest_single.rb
@@ -1,0 +1,26 @@
+class BlastestSingle < Formula
+  desc "blas test for veclibfort (single)"
+  homepage "https://tds.xyz"
+  url "https://gist.githubusercontent.com/davydden/1f9ebf3692beca2438f8/raw/0ba39c8775db3bb21c09c3440bf78ff5f778277d/blas.f90"
+  sha256 "9fad00d1d7e8d5d0be3c16fd25755c5d089205fae9dd4716481f8072a6a7f954"
+  version "1.0"
+
+  depends_on :fortran
+  depends_on :blas => :fortran
+
+  def install
+    blas_names = ENV["HOMEBREW_BLASLAPACK_NAMES"]
+    blas_lib   = ENV["HOMEBREW_BLASLAPACK_LIB"]
+    blas_inc   = ENV["HOMEBREW_BLASLAPACK_INC"]
+    ldflags    = blas_lib != "" ? "-L#{blas_lib} " : ""
+    ldflags   += blas_names.split(";").map { |word| "-l#{word}" }.join(" ")
+    ldflags   += " -pthread -lm"
+    cflags     = blas_inc != "" ? "-I#{blas_inc}"  : ""
+    system "#{ENV.fc} blas.f90 #{cflags} -o blastest_single #{ldflags}"
+    bin.install "blastest_single"
+  end
+ 
+  test do
+    system bin/"blastest_single"
+  end
+end

--- a/Library/Formula/blastest_single.rb
+++ b/Library/Formula/blastest_single.rb
@@ -9,13 +9,9 @@ class BlastestSingle < Formula
   depends_on :blas => :fortran
 
   def install
-    blas_names = ENV["HOMEBREW_BLASLAPACK_NAMES"]
-    blas_lib   = ENV["HOMEBREW_BLASLAPACK_LIB"]
-    blas_inc   = ENV["HOMEBREW_BLASLAPACK_INC"]
-    ldflags    = blas_lib != "" ? "-L#{blas_lib} " : ""
-    ldflags   += blas_names.split(";").map { |word| "-l#{word}" }.join(" ")
+    ldflags    = BlasRequirement.ldflags(ENV["HOMEBREW_BLASLAPACK_LIB"],ENV["HOMEBREW_BLASLAPACK_NAMES"])
     ldflags   += " -pthread -lm"
-    cflags     = blas_inc != "" ? "-I#{blas_inc}"  : ""
+    cflags     = BlasRequirement.cflags(ENV["HOMEBREW_BLASLAPACK_INC"])
     system "#{ENV.fc} blas.f90 #{cflags} -o blastest_single #{ldflags}"
     bin.install "blastest_single"
   end

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -126,6 +126,8 @@ class DependencyCollector
       Dependency.new("libtool", tags)
     when :python2
       PythonRequirement.new(tags)
+    when :blas
+      BlasRequirement.new(tags)
     else
       raise ArgumentError, "Unsupported special dependency #{spec.inspect}"
     end

--- a/Library/Homebrew/requirements.rb
+++ b/Library/Homebrew/requirements.rb
@@ -1,5 +1,6 @@
 require "requirement"
 require "requirements/apr_requirement"
+require "requirements/blas_requirement"
 require "requirements/fortran_requirement"
 require "requirements/language_module_requirement"
 require "requirements/minimum_macos_requirement"

--- a/Library/Homebrew/requirements/blas_requirement.rb
+++ b/Library/Homebrew/requirements/blas_requirement.rb
@@ -1,0 +1,47 @@
+require "requirement"
+
+class BlasRequirement < Requirement
+  fatal true
+  default_formula "openblas"
+
+  # This ensures that HOMEBREW_BLAS_CFLAGS and HOMEBREW_BLAS_LDFLAGS
+  # are always set. It does _not_ add them to CFLAGS or LDFLAGS; that
+  # should happen inside the formula.
+  env do
+    if @satisfied_result
+      ENV["HOMEBREW_BLAS_CFLAGS"] ||= ""
+      ENV["HOMEBREW_BLAS_LDFLAGS"] ||= "-lblas -llapack"
+    else
+      ENV["HOMEBREW_BLAS_CFLAGS"] = "-I#{Formula["openblas"].opt_include}"
+      ENV["HOMEBREW_BLAS_LDFLAGS"] = "-L#{Formula["openblas"].opt_lib} -lopenblas"
+    end
+  end
+
+  satisfy :build_env => true do
+    cflags = ENV["HOMEBREW_BLAS_CFLAGS"] || ""
+    ldflags = ENV["HOMEBREW_BLAS_LDFLAGS"] || "-lblas -llapack"
+    success = nil
+    Dir.mktmpdir do |tmpdir|
+      tmpdir = Pathname.new tmpdir
+      (tmpdir/"blastest.c").write <<-EOS.undent
+        double cblas_ddot(const int, const double*, const int, const double*, const int);
+        int main() {
+          double x[] = {1.0, 2.0, 3.0}, y[] = {4.0, 5.0, 6.0};
+          cblas_ddot(3, x, 1, y, 1);
+          return 0;
+        }
+      EOS
+      success = system "#{ENV["CC"]} #{cflags} #{tmpdir}/blastest.c -o #{tmpdir}/blastest #{ldflags}",
+                :err => "/dev/null"
+    end
+    if !success
+      opoo "BLAS not configured"
+      puts <<-EOS.undent
+        Falling back to brewed openblas. If you prefer to use a system BLAS,
+        please set HOMEBREW_BLAS_CFLAGS and HOMEBREW_BLAS_LDFLAGS to correct
+        values.
+      EOS
+    end
+    success
+  end
+end

--- a/Library/Homebrew/requirements/blas_requirement.rb
+++ b/Library/Homebrew/requirements/blas_requirement.rb
@@ -25,13 +25,27 @@ class BlasRequirement < Requirement
     end
   end
 
+  def self.ldflags(blas_lib,blas_names)
+    res  = blas_lib != "" ? "-L#{blas_lib} " : ""
+    res += blas_names.split(";").map { |word| "-l#{word}" }.join(" ")
+    return res
+  end
+
+  def self.cflags(blas_inc)
+    return blas_inc != "" ? "-I#{blas_inc}"  : ""
+  end
+
+  def self.full_path(blas_lib,blas_names,separator)
+    exten = (OS.mac?) ? "dylib" : "so"
+    return blas_names.split(";").map { |word| "#{blas_lib}/lib#{word}.#{exten}" }.join(separator)
+  end
+
   satisfy :build_env => true do
     blas_names = ENV["HOMEBREW_BLASLAPACK_NAMES"] || "blas;lapack"
     blas_lib   = ENV["HOMEBREW_BLASLAPACK_LIB"]   || ""
     blas_inc   = ENV["HOMEBREW_BLASLAPACK_INC"]   || ""
-    cflags     = blas_inc != "" ? "-I#{blas_inc}"  : ""
-    ldflags    = blas_lib != "" ? "-L#{blas_lib} " : ""
-    ldflags   += blas_names.split(";").map { |word| "-l#{word}" }.join(" ")
+    cflags     = BlasRequirement.cflags(blas_inc)
+    ldflags    = BlasRequirement.ldflags(blas_lib,blas_names)
     # MKL BLAS may want to link against libpthread (e.g. pthread_mutex_trylock)
     # and we most likely need basic math (atan2, sin, etc) from libm
     # Adding both won't make much harm:

--- a/Library/Homebrew/requirements/blas_requirement.rb
+++ b/Library/Homebrew/requirements/blas_requirement.rb
@@ -37,7 +37,8 @@ class BlasRequirement < Requirement
 
   def self.full_path(blas_lib,blas_names,separator)
     exten = (OS.mac?) ? "dylib" : "so"
-    return blas_names.split(";").map { |word| "#{blas_lib}/lib#{word}.#{exten}" }.join(separator)
+    tmp = blas_lib.chomp("/")
+    return blas_names.split(";").map { |word| "#{tmp}/lib#{word}.#{exten}" }.join(separator)
   end
 
   satisfy :build_env => true do

--- a/Library/Homebrew/requirements/blas_requirement.rb
+++ b/Library/Homebrew/requirements/blas_requirement.rb
@@ -4,22 +4,32 @@ class BlasRequirement < Requirement
   fatal true
   default_formula "openblas"
 
-  # This ensures that HOMEBREW_BLAS_CFLAGS and HOMEBREW_BLAS_LDFLAGS
-  # are always set. It does _not_ add them to CFLAGS or LDFLAGS; that
-  # should happen inside the formula.
+  # This ensures that HOMEBREW_BLASLAPACK_NAMES, HOMEBREW_BLASLAPACK_LIB 
+  # and HOMEBREW_BLASLAPACK_INC are always set. It does _not_ add them to 
+  # CFLAGS or LDFLAGS; that should happen inside the formula.
   env do
     if @satisfied_result
-      ENV["HOMEBREW_BLAS_CFLAGS"] ||= ""
-      ENV["HOMEBREW_BLAS_LDFLAGS"] ||= "-lblas -llapack"
+      ENV["HOMEBREW_BLASLAPACK_NAMES"] ||= "blas;lapack"
+      ENV["HOMEBREW_BLASLAPACK_LIB"]   ||= ""
+      ENV["HOMEBREW_BLASLAPACK_INC"]   ||= ""
     else
-      ENV["HOMEBREW_BLAS_CFLAGS"] = "-I#{Formula["openblas"].opt_include}"
-      ENV["HOMEBREW_BLAS_LDFLAGS"] = "-L#{Formula["openblas"].opt_lib} -lopenblas"
+      ENV["HOMEBREW_BLASLAPACK_NAMES"]   = "openblas"
+      ENV["HOMEBREW_BLASLAPACK_LIB"]     = "#{Formula["openblas"].opt_lib}"
+      ENV["HOMEBREW_BLASLAPACK_INC"]     = "#{Formula["openblas"].opt_include}"
     end
   end
 
   satisfy :build_env => true do
-    cflags = ENV["HOMEBREW_BLAS_CFLAGS"] || ""
-    ldflags = ENV["HOMEBREW_BLAS_LDFLAGS"] || "-lblas -llapack"
+    blas_names = ENV["HOMEBREW_BLASLAPACK_NAMES"] || "blas;lapack"
+    blas_lib   = ENV["HOMEBREW_BLASLAPACK_LIB"]   || ""
+    blas_inc   = ENV["HOMEBREW_BLASLAPACK_INC"]   || ""
+    cflags     = blas_inc != "" ? "-I#{blas_inc}"  : ""
+    ldflags    = blas_lib != "" ? "-L#{blas_lib} " : ""
+    ldflags   += blas_names.split(";").map { |word| "-l#{word}" }.join(" ")
+    # MKL BLAS may want to link against libpthread (e.g. pthread_mutex_trylock)
+    # and we most likely need basic math (atan2, sin, etc) from libm
+    # Adding both won't make much harm:
+    ldflags   += " -lpthread -lm"
     success = nil
     Dir.mktmpdir do |tmpdir|
       tmpdir = Pathname.new tmpdir
@@ -37,9 +47,11 @@ class BlasRequirement < Requirement
     if !success
       opoo "BLAS not configured"
       puts <<-EOS.undent
-        Falling back to brewed openblas. If you prefer to use a system BLAS,
-        please set HOMEBREW_BLAS_CFLAGS and HOMEBREW_BLAS_LDFLAGS to correct
-        values.
+        Falling back to brewed openblas. If you prefer to use a system BLAS, please set
+          HOMEBREW_BLASLAPACK_NAMES (e.g. "mkl_intel_lp64;mkl_sequential;mkl_core")
+          HOMEBREW_BLASLAPACK_LIB   (e.g. "${MKLROOT}/lib/intel64")
+          HOMEBREW_BLASLAPACK_INC   (e.g. "${MKLROOT}/include")
+        to correct values.
       EOS
     end
     success


### PR DESCRIPTION
supersedes https://github.com/Homebrew/linuxbrew/pull/511

I think we **need some testing on linux** before putting it to Homebrew.
@Rombur @dpo @tjhei @jppelteret could you please test it on your environment (perhaps on a fresh linuxbew)?

# Summary of :blas usage cases
1. library names (space/semicolon separated) + dir: [Hypre](https://github.com/davydden/homebrew-science/blob/mkl_dealii/hypre.rb#L39-L45), [Trilinos](https://github.com/davydden/homebrew-science/blob/mkl_dealii/trilinos.rb#L115-L120)
2. ldflags : [Superlu_dist](https://github.com/davydden/homebrew-science/blob/mkl_dealii/superlu_dist.rb#L31), [scalapack](https://github.com/davydden/homebrew-science/blob/mkl_dealii/scalapack.rb#L28-L29), [mumps](https://github.com/davydden/homebrew-science/blob/mkl_dealii/mumps.rb#L107-L108), [p4est](https://github.com/davydden/homebrew-science/blob/mkl_dealii/p4est.rb#L32)
3. full path (space/semicolon separated) : [Petsc](https://github.com/davydden/homebrew-science/blob/mkl_dealii/petsc.rb#L92-L93), [deal.II](https://github.com/davydden/homebrew-science/blob/mkl_dealii/dealii.rb#L58-L62) 

# Detailed instructions for CentOS
Below is the detailed instruction to make it work with CentOS cluster and native `openmpi`, `gcc`, `cmake`, `git`, `MKL`. 

## 1. Put to your bash
```
# CentOS related:
module load gcc
module load openmpi/1.7.2-gcc
module load mkl
module load cmake
module load git/2.2.1

# Linuxbrew
export HOMEBREW_BUILD_FROM_SOURCE=1
export HOMEBREW_PREFIX=$WOODYHOME/.linuxbrew
export HOMEBREW_LOGS=$WOODYHOME/Logs/HOMEBREW
export HOMEBREW_CACHE=$WOODYHOME/Cache/HOMEBREW
export PATH="$HOMEBREW_PREFIX/bin:$PATH"
export MANPATH="$HOMEBREW_PREFIX/share/man:$MANPATH"
export INFOPATH="$HOMEBREW_PREFIX/share/info:$INFOPATH"
export HOMEBREW_BLASLAPACK_NAMES="mkl_intel_lp64;mkl_sequential;mkl_core"
export HOMEBREW_BLASLAPACK_LIB="${MKLROOT}/lib/intel64"
export HOMEBREW_BLASLAPACK_INC="${MKLROOT}/include"

# may not be needed, but i did it:
export CC=mpicc
export CXX=mpicxx
export FC=mpif90
export FF=mpif77
```
If you want to use blas/lapack from Ubuntu, it should be enough just to ignore setting `HOMEBREW_BLASLAPACK_XXX`. For `openblas` on Linuxbrew one has to install it first before Step 9. (last one) and then add `HOMEBREW_BLASLAPACK_XXX` with correct values.


## 2. Get linuxbrew from this PR
```
git clone https://github.com/davydden/linuxbrew.git $HOMEBREW_PREFIX
cd $HOMEBREW_PREFIX
git checkout blas-dependency
```

## 3. Compile ruby if needed
Mine was too old, thus:
```
# compile ruby
wget https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.gz
tar xvzf ruby-2.2.3.tar.gz ruby-2.2.3
./configure --prefix=$HOMEBREW_PREFIX
make
make install
```

## 4. Make simlinks for GCC to make sure linuxbrew picks it up
```
ln -s `which gcc` $HOMEBREW_PREFIX/bin/gcc-`gcc -dumpversion |cut -d. -f1,2`
ln -s `which g++` $HOMEBREW_PREFIX/bin/g++-`g++ -dumpversion |cut -d. -f1,2`
ln -s `which gfortran` $HOMEBREW_PREFIX/bin/gfortran-`gfortran -dumpversion |cut -d. -f1,2`
```

## 5. Make simlinks for Cmake to avoid its installation in Linuxbrew 
```
mkdir -p $HOMEBREW_PREFIX/Cellar/cmake/HEAD/bin
ln -s `which cmake` $HOMEBREW_PREFIX/Cellar/cmake/HEAD/bin/
brew link cmake
```

## 6. Wrap mpirun and mpiexec if needed
On a cluster frontend i was not able to execute `mpirun` without extra flags, thus
```
## make MPI runnable on frontend with shared memory
cd $HOMEBREW_PREFIX
mkdir bin_temp
cd bin_temp
touch mpiexec

# put the following to the file (adjust path to mpiexec as needed):

#!/bin/bash
exec /apps/OpenMPI/1.8.3-gcc/bin/mpiexec --mca btl self,sm "$@"

# make the file executable:
chmod +x mpiexec

# do the same steps for mpirun
```


## 7. Get openssl
```
brew install openssl
brew postinstall openssl
```

## 8. Get modified homebrew-science
i updated formulae used below for the new `:blas` dependency
```
brew tap davydden/science
cd $HOMEBREW_PREFIX/Library/Taps/davydden/homebrew-science
# branch name is misleading, it's not MKL only! At least it should not be :-)
git checkout mkl_dealii
```

## 9. Install minimal deal.II suite
```
# in case you wrap mpirun and mpiexec
export PATH_OLD=$PATH
export PATH="$HOMEBREW_PREFIX/bin_temp:$PATH"

# finally install
brew install hdf5 --with-mpi --c++11
brew install hypre --with-mpi
brew install metis
brew install parmetis
brew install superlu_dist
brew test superlu_dist

# i installed without check because it tries to run mpiexec directly,
# no the wrapper i created => failures on front end of the cluster
brew install scalapack --without-check
brew install mumps
brew test mumps

brew install petsc --without-fftw --without-hwloc --without-netcdf --without-suite-sparse --without-sundials --without-superlu
brew install slepc --without-arpack
brew install p4est
brew install trilinos --without-x11 --without-adol-c --without-cppunit --without-doxygen --without-hwloc --without-libmatio  --without-netcdf --without-scotch --without-suite-sparse --without-eigen --without-glpk --without-tbb --without-glm --without-yaml-cpp
brew install dealii --HEAD --without-arpack --without-hdf5 --without-muparser --without-netcdf --without-opencascade --without-suite-sparse --without-tbb
```

## 10. Test metis
```
export LD_LIBRARY_PATH_OLD=$LD_LIBRARY_PATH
export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOMEBREW_PREFIX/lib"
brew test metis
brew test parmetis
export LD_LIBRARY_PATH=$LD_LIBRARY_PATH_OLD

```