### PR TITLE
jdk, jdk7: fix JdkDownloadStrategy for Linuxbrew

### DIFF
--- a/Library/Formula/jdk.rb
+++ b/Library/Formula/jdk.rb
@@ -1,8 +1,6 @@
 class JdkDownloadStrategy < CurlDownloadStrategy
-  def _fetch
-    raise "On Mac OS try instead `brew cask install java`" if OS.mac?
-    curl @url, "-C", downloaded_size, "-o", temporary_path,
-      "--cookie", "oraclelicense=accept-securebackup-cookie"
+  def _curl_opts
+    super << "--cookie" << "oraclelicense=accept-securebackup-cookie"
   end
 end
 

--- a/Library/Formula/jdk7.rb
+++ b/Library/Formula/jdk7.rb
@@ -1,10 +1,8 @@
 require "formula"
 
 class JdkDownloadStrategy < CurlDownloadStrategy
-  def _fetch
-    raise "On Mac OS try instead `brew cask install java`" if OS.mac?
-    curl @url, "-C", downloaded_size, "-o", temporary_path,
-      "--cookie", "oraclelicense=accept-securebackup-cookie"
+  def _curl_opts
+    super << "--cookie" << "oraclelicense=accept-securebackup-cookie"
   end
 end
 

--- a/Library/Formula/jdk7.rb
+++ b/Library/Formula/jdk7.rb
@@ -1,5 +1,3 @@
-require "formula"
-
 class JdkDownloadStrategy < CurlDownloadStrategy
   def _curl_opts
     super << "--cookie" << "oraclelicense=accept-securebackup-cookie"


### PR DESCRIPTION
Hopefully fixes #595 by adding the `-L` option to `curl` to follow redirects.

I had to make the change twice, in both `jdk` and `jdk7`. Is it worth it to factor out that identical `JdkDownloadStrategy` elsewhere?