### PR TITLE
qemu: Disable cocoa when not on Mac.

### DIFF
--- a/Library/Formula/qemu.rb
+++ b/Library/Formula/qemu.rb
@@ -42,7 +42,7 @@ class Qemu < Formula
     if build.with?("sdl") && build.head?
       args << "--disable-cocoa"
     else
-      args << "--enable-cocoa"
+      args << "--enable-cocoa" if OS.mac?
     end
 
     args << (build.with?("sdl") ? "--enable-sdl" : "--disable-sdl")


### PR DESCRIPTION
Not needed on Linux and causes build fail.

```
audio/coreaudio.c:25:33: fatal error: CoreAudio/CoreAudio.h: No such file or directory
compilation terminated.
/tmp/qemu20151014-30132-14zgt0d/qemu-2.4.0.1/rules.mak:57: recipe for target 'audio/coreaudio.o' failed
make: *** [audio/coreaudio.o] Error 1
```