### PR TITLE
Ensure gpatch when patch step exists.

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -145,6 +145,7 @@ class SoftwareSpec
   end
 
   def patch(strip = :p1, src = nil, &block)
+    dependency_collector.add("homebrew/dupes/gpatch") unless OS.mac?
     patches << Patch.create(strip, src, &block)
   end
 


### PR DESCRIPTION
When installing Linuxbrew Standalone on an almost bare system (think embedded-ish here) `patch` may not be available. Add it to dependencies when needed.