### PR TITLE
LinuxBrew with PIE: Permissions get wrongly 'cleaned'

### DIFF
--- a/Library/Homebrew/cleaner.rb
+++ b/Library/Homebrew/cleaner.rb
@@ -87,7 +87,7 @@ class Cleaner
         path.unlink
       else
         # Set permissions for executables and non-executables
-        perms = if path.mach_o_executable? || path.text_executable?
+        perms = if path.mach_o_executable? || path.dylib? || path.text_executable?
           0555
         else
           0444

--- a/Library/Homebrew/test/test_cleaner.rb
+++ b/Library/Homebrew/test/test_cleaner.rb
@@ -23,9 +23,9 @@ class CleanerTests < Homebrew::TestCase
     Cleaner.new(@f).clean
 
     assert_equal 0100555, (@f.bin/"a.out").stat.mode
-    assert_equal 0100444, (@f.lib/"fat.dylib").stat.mode
-    assert_equal 0100444, (@f.lib/"x86_64.dylib").stat.mode
-    assert_equal 0100444, (@f.lib/"i386.dylib").stat.mode
+    assert_equal 0100555, (@f.lib/"fat.dylib").stat.mode
+    assert_equal 0100555, (@f.lib/"x86_64.dylib").stat.mode
+    assert_equal 0100555, (@f.lib/"i386.dylib").stat.mode
   end
 
   def test_prunes_prefix_if_empty


### PR DESCRIPTION
**tl;dr**: `alpine$ brew install hello && brew test hello` fails with insufficient permissions due to PIE.

Alpine Linux (and possibly others) produce [Position Independent Executables](https://en.wikipedia.org/wiki/Position-independent_code), which take the form of shared libraries.
However, from an ELF and therefore from a `path.mach_o_executable?` point of view those are not really `executable`s, which leads to them wrongfully getting `chmod 0444`ed.

## Steps to reproduce

    cat > Dockerfile <<EOF
    FROM alpine
    RUN apk update &&\
      apk add git make clang ruby ruby-irb ncurses tar binutils build-base &&\
      git clone https://github.com/Homebrew/linuxbrew.git ~/brew
    RUN /root/brew/bin/brew install hello
    RUN /root/brew/bin/brew test hello
    EOF
    docker build .

## Suggestion to fix

There is no harm in having libraries executable. In fact, they usually _are_ marked executable anyways. I suggest expanding the check in [Library/Homebrew/cleaner.rb:90](https://github.com/Homebrew/linuxbrew/blob/master/Library/Homebrew/cleaner.rb#L90)

```ruby
perms = if path.mach_o_executable? || path.text_executable?
```

to

```ruby
perms = if path.mach_o_executable? || path.dylib? || path.text_executable?
```

EDIT: I'm unable to run the tests on my machine... It seems to expect to be run on a Mac?