### PR TITLE
(Work in Progress) squirrel-sql (new formula)

### DIFF
--- a/Library/Formula/squirrel-sql.rb
+++ b/Library/Formula/squirrel-sql.rb
@@ -1,0 +1,43 @@
+class SquirrelSql < Formula
+  desc "GUI for JDBC-compliant databases"
+  homepage "http://www.squirrelsql.org/"
+  head "git://git.code.sf.net/p/squirrel-sql/git"
+
+  depends_on "ant" => :build
+  depends_on :java
+
+  def install
+    cd "sql12" do
+      system "ant"
+      cd buildpath/"sql12/output/plainZip" do 
+        zipfile = Dir.glob("squirrelsql-snapshot-*_*-standard.zip")[0]
+        system "unzip", zipfile
+        unzipped = zipfile[0 ... -4] # trim off the ".zip"
+        cd unzipped do
+          # install the libraries
+          lib.install Dir["lib/*.jar"]
+          
+          # fix home location
+          inreplace "squirrel-sql.sh", "SQUIRREL_SQL_HOME=`dirname \"$0\"`", "SQUIRREL_SQL_HOME=#{prefix}"
+          
+          # install the shell script
+          bin.install "squirrel-sql.sh"
+          bin.install_symlink "squirrel-sql.sh" => "squirrel-sql"
+          
+          # install the JAR
+          lib.install "squirrel-sql.jar"
+        end
+      end
+    end
+  end
+        
+  def caveats
+    <<-EOS.undent
+    The plugins have not been installed because I'm lazy.
+    EOS
+  end
+
+  test do
+    system "false"
+  end
+end


### PR DESCRIPTION
This PR introduces a new package - `squirrel-sql` (so named to avoid confusing users of the existing `squirrel` package). Its homepage is http://www.squirrelsql.org/.

@bfontaine recommended [here](https://github.com/Homebrew/homebrew/issues/45239) that I open this PR against Linuxbrew first so I don't have to worry about something OS X-specific failing while I'm developing on Linux. Given that Squirrel's build system and directory layout are both kind of quirky and its launcher script has some Mac-specific hackery, the odds of that happening are relatively high, even for a Java-based formula.

This is a work in progress: the following issues (at least) still need to be resolved:
1. The splash screen doesn't work
2. The plugins aren't installed (currently that's listed as a caveat, but it's something I intend to eventually fix)
3. My formula is currently head-only - the upstream developers do make stable releases, but I suspect the build process might differ slightly based on whether you're doing a head or stable build.
4. Several libraries (JAR archives) are effectively bundled, and they'll need to be unbundled
5. The formula probably doesn't pass an audit yet, but I decided not to worry about that too much for now.
6. No test written yet
7. The icons aren't installed
8. The Git commit messages aren't the standard you expect (but that can be fixed easily enough before merging).
9. I think some of the documentation might still need to be installed.

I know that sounds like a lot of problems, but I think the sooner I open this PR the less likely someone is to duplicate effort. Any help with the formula is welcome!

The current status: you can build it with `--HEAD` and run the launcher script, which will both a) launch the GUI and b) throw a lot of Java exceptions and logging messages at you. 