### PR TITLE
llvm: Include the libcxxabi component

### DIFF
--- a/Library/Formula/llvm.rb
+++ b/Library/Formula/llvm.rb
@@ -35,6 +35,11 @@ class Llvm < Formula
       sha256 "52f3d452f48209c9df1792158fdbd7f3e98ed9bca8ebb51fcd524f67437c8b81"
     end
 
+    resource "libcxxabi" do
+      url "http://llvm.org/releases/3.6.2/libcxxabi-3.6.2.src.tar.xz"
+      sha256 "6fb48ce5a514686b9b75e73e59869f782ed374a86d71be8423372e4b3329b09b"
+    end
+
     resource "lld" do
       url "http://llvm.org/releases/3.6.2/lld-3.6.2.src.tar.xz"
       sha256 "43f553c115563600577764262f1f2fac3740f0c639750f81e125963c90030b33"
@@ -68,6 +73,10 @@ class Llvm < Formula
 
     resource "libcxx" do
       url "http://llvm.org/git/libcxx.git"
+    end
+
+    resource "libcxxabi" do
+      url "http://llvm.org/git/libcxxabi.git"
     end
 
     resource "lld" do
@@ -124,6 +133,7 @@ class Llvm < Formula
 
     if build.with? "clang"
       (buildpath/"projects/libcxx").install resource("libcxx")
+      (buildpath/"projects/libcxxabi").install resource("libcxxabi")
       (buildpath/"tools/clang").install resource("clang")
       (buildpath/"tools/clang/tools/extra").install resource("clang-tools-extra")
     end
@@ -159,6 +169,11 @@ class Llvm < Formula
 
     if build.with? "clang"
       if OS.linux?
+        mktemp do
+          system "cmake", "-G", "Unix Makefiles", "#{buildpath}/projects/libcxxabi", *std_cmake_args
+          system "make"
+          system "make", "install"
+        end
         # libcxx fails to build with gcc.
         ENV["CC"] = bin/"clang"
         ENV["CXX"] = bin/"clang++"
@@ -171,6 +186,8 @@ class Llvm < Formula
         # Installation on Mac OS X doesn't require CMake approach
         system "make", "-C", "projects/libcxx", "install",
           "DSTROOT=#{prefix}", "SYMROOT=#{buildpath}/projects/libcxx"
+        system "make", "-C", "projects/libcxxabi", "install",
+          "DSTROOT=#{prefix}", "SYMROOT=#{buildpath}/projects/libcxxabi"
       end
 
       (share/"clang/tools").install Dir["tools/clang/tools/scan-{build,view}"]


### PR DESCRIPTION
This is required for `rtags` to build.