### PR TITLE
gmp: Adding flag for compiling on the Raspberry Pi

### DIFF
--- a/Library/Formula/gmp.rb
+++ b/Library/Formula/gmp.rb
@@ -30,6 +30,9 @@ class Gmp < Formula
 
     # https://github.com/Homebrew/homebrew/issues/20693
     args << "--disable-assembly" if build.build_32_bit? || build.bottle?
+    
+    # For compiling on a Raspberry Pi
+    args << "--build=arm" if Hardware::CPU.type == :arm
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
Without this flag is impossible to meet the requirements to compile GCC5 in a Raspberry Pi