### PR TITLE
Update centos installation instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
 <h3>
 <a id="centos" class="anchor" href="#centos" aria-hidden="true"><span class="octicon octicon-link"></span></a>Centos</h3>
 
-<div class="highlight highlight-sh"><pre>sudo yum groupinstall <span class="pl-s1"><span class="pl-pds">'</span>Development Tools<span class="pl-pds">'</span></span> <span class="pl-k">&amp;&amp;</span> sudo yum install curl git m4 ruby ruby-irb texinfo bzip2-devel curl-devel expat-devel ncurses-devel zlib-devel</pre></div>
+<div class="highlight highlight-sh"><pre>sudo yum groupinstall <span class="pl-s1"><span class="pl-pds">'</span>Development Tools<span class="pl-pds">'</span></span> <span class="pl-k">&amp;&amp;</span> sudo yum install curl git m4 ruby ruby-irb texinfo bzip2-devel curl-devel expat-devel ncurses-devel libX11-devel zlib-devel</pre></div>
 
 <h2>
 <a id="installation" class="anchor" href="#installation" aria-hidden="true"><span class="octicon octicon-link"></span></a>Installation</h2>

--- a/index.html
+++ b/index.html
@@ -75,6 +75,10 @@
 <a id="fedora" class="anchor" href="#fedora" aria-hidden="true"><span class="octicon octicon-link"></span></a>Fedora</h3>
 
 <div class="highlight highlight-sh"><pre>sudo yum groupinstall <span class="pl-s1"><span class="pl-pds">'</span>Development Tools<span class="pl-pds">'</span></span> <span class="pl-k">&amp;&amp;</span> sudo yum install curl git m4 ruby texinfo bzip2-devel curl-devel expat-devel ncurses-devel zlib-devel</pre></div>
+<h3>
+<a id="centos" class="anchor" href="#centos" aria-hidden="true"><span class="octicon octicon-link"></span></a>Centos</h3>
+
+<div class="highlight highlight-sh"><pre>sudo yum groupinstall <span class="pl-s1"><span class="pl-pds">'</span>Development Tools<span class="pl-pds">'</span></span> <span class="pl-k">&amp;&amp;</span> sudo yum install curl git m4 ruby ruby-irb texinfo bzip2-devel curl-devel expat-devel ncurses-devel zlib-devel</pre></div>
 
 <h2>
 <a id="installation" class="anchor" href="#installation" aria-hidden="true"><span class="octicon octicon-link"></span></a>Installation</h2>


### PR DESCRIPTION
For centos 6.7 (at least), the "ruby" package doesn't pull in irb. Update instructions for centos to pull it in.