### PR TITLE
boost.rb with gcc now compiles boost.log on linux

### DIFF
--- a/Library/Formula/boost.rb
+++ b/Library/Formula/boost.rb
@@ -88,7 +88,7 @@ class Boost < Formula
 
     # Boost.Log cannot be built using Apple GCC at the moment. Disabled
     # on such systems.
-    without_libraries << "log" if ENV.compiler == :gcc || ENV.compiler == :llvm
+    without_libraries << "log" if OS.mac? && (ENV.compiler == :gcc || ENV.compiler == :llvm)
     without_libraries << "mpi" if build.without? "mpi"
 
     bootstrap_args << "--without-libraries=#{without_libraries.join(",")}"


### PR DESCRIPTION
eventually it would be ideal to only enable this if the gcc version is >=4.5
https://github.com/Homebrew/homebrew/issues/45954