### PR TITLE
loudmouth install step fails on Debian

### DIFF
--- a/Library/Formula/loudmouth.rb
+++ b/Library/Formula/loudmouth.rb
@@ -46,6 +46,7 @@ class Loudmouth < Formula
   end
 
   def install
+    ENV['LIBS'] = '-lgobject-2.0'
     system "./autogen.sh", "-n" if build.head?
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}", "--with-ssl=gnutls"


### PR DESCRIPTION
I'm getting an error installing loudmouth on Debian. Here is the error log:

```
Last 15 lines from /home/users/jesse/.cache/Homebrew/Logs/loudmouth/02.make:
libtool: link: /usr/bin/gcc-4.9 -Os -w -pipe -march=core2 -Wall -I/home/users/jesse/.linuxbrew/Cellar/gnutls/3.3.18/include -I/home/users/jesse/.linuxbrew/Cellar/nettle/2.7.1/include -I/home/users/jesse/.linuxbrew/Cellar/libtasn1/4.7/include -Wall -Wunused -Wchar-subscripts -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wpointer-arith -Wno-sign-compare -Werror -Wl,-rpath -Wl,/home/users/jesse/.linuxbrew/lib -o .libs/test-dns test-dns.o  -L/home/users/jesse/.linuxbrew/lib -L/home/users/jesse/.linuxbrew/Cellar/glib/2.46.0/lib -lglib-2.0 ./.libs/libloudmouth-1.so -lnsl -L/home/users/jesse/.linuxbrew/Cellar/gnutls/3.3.18/lib -lgnutls -Wl,-rpath -Wl,/home/users/jesse/.linuxbrew/Cellar/loudmouth/1.5.0.20121201_1/lib
/usr/bin/ld: test-dns.o: undefined reference to symbol 'g_object_get'
/home/users/jesse/.linuxbrew/lib/libgobject-2.0.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```

It appears the problem is that the linker is not told to include gobject. This patch fixes the problem on my system. Unfortunately I do not have much experience fixing build problems, so my fix may be excessively blunt.

Output of uname -a:

```
Linux hood 3.14-2-amd64 #1 SMP Debian 3.14.15-2 (2014-08-09) x86_64 GNU/Linux
```