### PR TITLE
Fixed OS detection on Linux reporting "java" instead of "linux"

### DIFF
--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -1,10 +1,12 @@
+require 'rbconfig'
+
 module OS
   def self.mac?
     /darwin/i === RUBY_PLATFORM
   end
 
   def self.linux?
-    /linux/i === RUBY_PLATFORM
+    /linux/i === RUBY_PLATFORM || /linux/i === RbConfig::CONFIG['host_os']
   end
 
   if OS.mac?


### PR DESCRIPTION
Some Linux distros come with JRuby pre-installed (e.g. Fedora). Since I never use Ruby, I never noticed, but when the installer failed, reporting "java" as the "unknown os", I realized the RUBY_PLATFORM constant always reports "java" for JRuby - regardless of the actual host OS.

This just adds an extra check for Linux. You may consider not using RUBY_PLATFORM at all, but that's up to you.