### PR TITLE
Fix erroneous MySQL dependencies

### DIFF
--- a/Library/Formula/mysql.rb
+++ b/Library/Formula/mysql.rb
@@ -16,6 +16,7 @@ class Mysql < Formula
   depends_on "openssl"
   # Fix error: Cannot find system editline libraries.
   depends_on "libedit" unless OS.mac?
+  depends_on "boost"
 
   option :universal
   option "with-tests", "Build with unit tests"
@@ -29,11 +30,6 @@ class Mysql < Formula
   deprecated_option "enable-local-infile" => "with-local-infile"
   deprecated_option "enable-memcached" => "with-memcached"
   deprecated_option "enable-debug" => "with-debug"
-
-  depends_on "cmake" => :build
-  depends_on "pidof" unless MacOS.version >= :mountain_lion
-  depends_on "openssl"
-  depends_on "boost"
 
   conflicts_with "mysql-cluster", "mariadb", "percona-server",
     :because => "mysql, mariadb, and percona install the same binaries."


### PR DESCRIPTION
Remove duplicate `depends_on` declarations for `cmake`, `pidof` and `openssl`. Specifically the duplicate `depends_on pidof` without the `!OS.mac?` guard was breaking the build on non-Mac OS's. See line 15 of the same file for the correct declaration.

This fixes the issue I filed: https://github.com/Homebrew/linuxbrew/issues/670

However it seems like the build _still_ will not complete due to some issue with Boost (which will now attempt to build without the `pidof` failure). I'll file a separate issue for that.