### PR TITLE
moz-git-tools 0.1 (import from head-only)

### DIFF
--- a/Library/Formula/moz-git-tools.rb
+++ b/Library/Formula/moz-git-tools.rb
@@ -1,0 +1,36 @@
+class MozGitTools < Formula
+  desc "Tools for working with Git at Mozilla"
+  homepage "https://github.com/mozilla/moz-git-tools"
+  url "https://github.com/mozilla/moz-git-tools/archive/v0.1.zip"
+  sha256 "e05b84b4e989cf2ad6eb849af2cb2c2b6ffa939e32e77e07bc6e31c4a3dc7e86"
+
+  head "https://github.com/mozilla/moz-git-tools.git"
+
+  def install
+    # Install all the executables, except git-root since that conflicts with git-extras
+    bin_array = Dir.glob("git*").push("hg-patch-to-git-patch")
+    bin_array.delete("git-root")
+    bin_array.delete("git-bz-moz") # a directory, not an executable
+    bin_array.each { |e| bin.install e }
+  end
+
+  def caveats
+    <<-EOS.undent
+    git-root was not installed because it conflicts with the version provided by git-extras.
+    EOS
+  end
+
+  test do
+    # create a Git repo and check its branchname
+    (testpath/".gitconfig").write <<-EOS.undent
+      [user]
+        name = Real Person
+        email = notacat@hotmail.cat
+      EOS
+    system "git", "init"
+    (testpath/"myfile").write("my file")
+    system "git", "add", "myfile"
+    system "git", "commit", "-m", "test"
+    assert_match /master/, shell_output("#{bin}/git-branchname")
+  end
+end


### PR DESCRIPTION
This imports moz-git-tools version 0.1 into Homebrew core.

I haven't made the commit to remove it from head-only yet; I will soon.