### PR TITLE
Troubleshooting: update link.

### DIFF
--- a/share/doc/homebrew/Troubleshooting.md
+++ b/share/doc/homebrew/Troubleshooting.md
@@ -1,1 +1,1 @@
-Moved to https://github.com/Linuxbrew/brew/blob/master/share/doc/homebrew/Troubleshooting.md.
+Moved to https://github.com/Linuxbrew/brew/blob/master/docs/Troubleshooting.md


### PR DESCRIPTION
![brew](https://user-images.githubusercontent.com/74308/30956004-3d5ec738-a468-11e7-8517-1ca0c48ba966.PNG)

still leads to the `legacy-linuxbrew` project so i figured it this might still  be the right project to put this PR.
